### PR TITLE
Remove version from build logic

### DIFF
--- a/.github/workflows/check-new-api-spec.yml
+++ b/.github/workflows/check-new-api-spec.yml
@@ -1,13 +1,22 @@
 name: 'Check for new API spec version'
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run'
+        type: boolean
+        required: false
+  pull_request:
 
 defaults:
   run:
     shell: bash
+
+env:
+  DRY_RUN: ${{ github.event.inputs.dry_run || github.event_name == 'pull_request' }}
 
 jobs:
 
@@ -24,6 +33,7 @@ jobs:
           [[ -n "$version" ]]
           echo "SPEC_VERSION=$version" | tee -a "$GITHUB_ENV"
       - name: 'Create PR'
+        if: ${{ DRY_RUN == 'false' }}
         uses: peter-evans/create-pull-request@v4
         with:
           branch: "feature/api-spec-${{ env.SPEC_VERSION }}"

--- a/.github/workflows/check-new-api-spec.yml
+++ b/.github/workflows/check-new-api-spec.yml
@@ -9,7 +9,7 @@ on:
         description: 'Dry run'
         type: boolean
         required: false
-  pull_request:
+  workflow_call:
 
 defaults:
   run:

--- a/.github/workflows/check-new-api-spec.yml
+++ b/.github/workflows/check-new-api-spec.yml
@@ -33,7 +33,7 @@ jobs:
           [[ -n "$version" ]]
           echo "SPEC_VERSION=$version" | tee -a "$GITHUB_ENV"
       - name: 'Create PR'
-        if: ${{ DRY_RUN == 'false' }}
+        if: ${{ env.DRY_RUN == 'false' }}
         uses: peter-evans/create-pull-request@v4
         with:
           branch: "feature/api-spec-${{ env.SPEC_VERSION }}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,7 +46,28 @@ jobs:
         run: python3 -m unittest discover -bs .github/scripts
 
   publish-javadoc-dry-run:
-    uses: ./.github/workflows/publish-javadoc.yml
+    - name: Check for modified code
+        id: diff
+        uses: tj-actions/changed-files@v24
+        with:
+          files: |
+            .github/workflows/publish-javadoc.yml
+            .github/scripts/*
+            **/src/**
+            **/*.gradle*
+            ./gradle/*
+    - name: Trigger dry run
+      if: ${{ steps.diff.outputs.all_modified_files }}
+      uses: ./.github/workflows/publish-javadoc.yml
 
   check-new-api-spec-dry-run:
-    uses: ./.github/workflows/check-new-api-spec.yml
+    - name: Check for modified code
+        id: diff
+        uses: tj-actions/changed-files@v24
+        with:
+          files: |
+            .github/workflows/check-new-api-spec.yml
+            .github/scripts/*
+    - name: Trigger dry run
+      if: ${{ steps.diff.outputs.all_modified_files }}
+      uses: ./.github/workflows/check-new-api-spec.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,28 +46,7 @@ jobs:
         run: python3 -m unittest discover -bs .github/scripts
 
   publish-javadoc-dry-run:
-    - name: Check for modified code
-        id: diff
-        uses: tj-actions/changed-files@v24
-        with:
-          files: |
-            .github/workflows/publish-javadoc.yml
-            .github/scripts/*
-            **/src/**
-            **/*.gradle*
-            ./gradle/*
-    - name: Trigger dry run
-      if: ${{ steps.diff.outputs.all_modified_files }}
-      uses: ./.github/workflows/publish-javadoc.yml
+    uses: ./.github/workflows/publish-javadoc.yml
 
   check-new-api-spec-dry-run:
-    - name: Check for modified code
-        id: diff
-        uses: tj-actions/changed-files@v24
-        with:
-          files: |
-            .github/workflows/check-new-api-spec.yml
-            .github/scripts/*
-    - name: Trigger dry run
-      if: ${{ steps.diff.outputs.all_modified_files }}
-      uses: ./.github/workflows/check-new-api-spec.yml
+    uses: ./.github/workflows/check-new-api-spec.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,3 +44,9 @@ jobs:
       - name: 'unittest discover'
         if: ${{ steps.diff.outputs.all_modified_files }}
         run: python3 -m unittest discover -bs .github/scripts
+
+  publish-javadoc-dry-run:
+    uses: ./.github/workflows/publish-javadoc.yml
+
+  check-new-api-spec-dry-run:
+    uses: ./.github/workflows/check-new-api-spec.yml

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Fetch branch
-        run: git fetch gh-pages && git checkout FETCH_HEAD
+        run: git fetch origin gh-pages && git checkout FETCH_HEAD
       - name: Download javadoc
         uses: actions/download-artifact@v3
       - name: Unzip javadoc

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -4,12 +4,19 @@ on:
   push:
     tags: ['*']
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run'
+        type: boolean
+        required: false
+  pull_request:
 
 defaults:
   run:
     shell: bash
 
 env:
+  DRY_RUN: ${{ github.event.inputs.dry_run || github.event_name == 'pull_request' }}
   JAR_NAME: gradle-enterprise-api-kotlin-SNAPSHOT-javadoc.jar
 
 jobs:
@@ -43,4 +50,6 @@ jobs:
           unzip "$JAR_NAME" -d docs
           git add docs
           git commit -m "Add ${{ github.ref_name }} javadoc"
-          git push
+          if [[ "$DRY_RUN" == 'false' ]]; then
+            git push
+          fi

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -4,35 +4,27 @@ on:
   push:
     tags: ['*']
   workflow_dispatch:
-    inputs:
-      version_name:
-        description: 'Version'
-        required: true
 
 defaults:
   run:
     shell: bash
 
 env:
-  VERSION_NAME: ${{ github.event.inputs.version_name || github.ref_name }}
+  JAR_NAME: gradle-enterprise-api-kotlin-SNAPSHOT-javadoc.jar
 
 jobs:
 
   build-javadoc:
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ env.VERSION }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ env.VERSION_NAME }}
       - name: Build javadoc
         uses: ./.github/actions/build
         with:
           tasks: 'javadocJar'
           artifact-name: 'javadoc'
-          path-to-upload: "build/libs/gradle-enterprise-api-kotlin-${{ env.VERSION_NAME }}-javadoc.jar"
+          path-to-upload: "build/libs/${{ env.JAR_NAME }}"
 
   commit-to-gh-pages:
     needs: [build-javadoc]
@@ -40,8 +32,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ env.VERSION_NAME }}
       - name: Download javadoc
         uses: actions/download-artifact@v3
       - name: Commit and push
@@ -50,7 +40,7 @@ jobs:
           git config user.email github-actions@github.com
           git checkout gh-pages
           rm -rf docs
-          unzip "gradle-enterprise-api-kotlin-$VERSION_NAME-javadoc.jar" -d docs
+          unzip "$JAR_NAME" -d docs
           git add docs
-          git commit -m "Add $VERSION_NAME javadoc"
+          git commit -m "Add ${{ github.ref_name }} javadoc"
           git push

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -39,15 +39,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Fetch branch
+        run: git fetch gh-pages && git checkout FETCH_HEAD
       - name: Download javadoc
         uses: actions/download-artifact@v3
+      - name: Unzip javadoc
+        run: rm -rf docs && unzip "$JAR_NAME" -d docs
       - name: Commit
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git checkout gh-pages
-          rm -rf docs
-          unzip "$JAR_NAME" -d docs
           git add docs
           git commit -m "Add ${{ github.ref_name }} javadoc"
       - name: Push

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Download javadoc
         uses: actions/download-artifact@v3
-      - name: Commit and push
+      - name: Commit
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -50,6 +50,9 @@ jobs:
           unzip "$JAR_NAME" -d docs
           git add docs
           git commit -m "Add ${{ github.ref_name }} javadoc"
-          if [[ "$DRY_RUN" == 'false' ]]; then
-            git push
+      - name: Push
+        run: |
+          if [[ "$DRY_RUN" == 'true' ]]; then
+            args=' --dry-run'
           fi
+          git push $args

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -33,7 +33,7 @@ jobs:
           artifact-name: 'javadoc'
           path-to-upload: "build/libs/${{ env.JAR_NAME }}"
 
-  commit-to-gh-pages:
+  publish-javadoc:
     needs: [build-javadoc]
     runs-on: ubuntu-latest
     steps:
@@ -56,4 +56,4 @@ jobs:
           if [[ "$DRY_RUN" == 'true' ]]; then
             args=' --dry-run'
           fi
-          git push $args
+          git push origin HEAD:gh-pages $args

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Download javadoc
         uses: actions/download-artifact@v3
       - name: Unzip javadoc
-        run: rm -rf docs && unzip "$JAR_NAME" -d docs
+        run: rm -rf docs && unzip "javadoc/$JAR_NAME" -d docs
       - name: Commit
         run: |
           git config user.name github-actions

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -9,7 +9,7 @@ on:
         description: 'Dry run'
         type: boolean
         required: false
-  pull_request:
+  workflow_call:
 
 defaults:
   run:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "com.github.gabrielfeo"
-version = "0.10.0"
+version = "SNAPSHOT"
 val repoUrl = "https://github.com/gabrielfeo/gradle-enterprise-api-kotlin"
 
 val downloadApiSpec by tasks.registering {


### PR DESCRIPTION
JitPack will pass `-Pversion` and version doesn't matter for javadoc.
Removes the need of "prepare for next version" commits.

Also, dry run GitHub actions on PRs as a limited form of testing.