### PR TITLE
Rename env var for API URL

### DIFF
--- a/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/Options.kt
+++ b/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/Options.kt
@@ -36,16 +36,16 @@ class Options internal constructor(
 
         /**
          * Provides the URL of a Gradle Enterprise API instance (without `/api`). By default, uses
-         * environment variable `GRADLE_ENTERPRISE_URL`.
+         * environment variable `GRADLE_ENTERPRISE_API_URL`.
          */
         var url: () -> String = {
-            env["GRADLE_ENTERPRISE_URL"]
+            env["GRADLE_ENTERPRISE_API_URL"]
                 ?: error("GE instance URL is required")
         }
 
         /**
          * Provides the access token for a Gradle Enterprise API instance. By default, uses keychain entry
-         * `gradle-enterprise-api-token` or environment variable `GRADLE_ENTERPRISE_URL`.
+         * `gradle-enterprise-api-token` or environment variable `GRADLE_ENTERPRISE_API_TOKEN`.
          */
         var token: () -> String = {
             keychain["gradle-enterprise-api-token"]

--- a/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/Options.kt
+++ b/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/Options.kt
@@ -40,7 +40,7 @@ class Options internal constructor(
          */
         var url: () -> String = {
             env["GRADLE_ENTERPRISE_API_URL"]
-                ?: error("GE instance URL is required")
+                ?: error("GRADLE_ENTERPRISE_API_URL is required")
         }
 
         /**
@@ -50,7 +50,7 @@ class Options internal constructor(
         var token: () -> String = {
             keychain["gradle-enterprise-api-token"]
                 ?: env["GRADLE_ENTERPRISE_API_TOKEN"]
-                ?: error("GE token is required")
+                ?: error("GRADLE_ENTERPRISE_API_TOKEN is required")
         }
     }
 

--- a/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/Options.kt
+++ b/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/Options.kt
@@ -35,8 +35,8 @@ class Options internal constructor(
     ) {
 
         /**
-         * Provides the URL of a Gradle Enterprise API instance (without `/api`). By default, uses
-         * environment variable `GRADLE_ENTERPRISE_API_URL`.
+         * Provides the URL of a Gradle Enterprise API instance REST API. By default, uses
+         * environment variable `GRADLE_ENTERPRISE_API_URL`. Must end with `/api/`.
          */
         var url: () -> String = {
             env["GRADLE_ENTERPRISE_API_URL"]

--- a/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/Retrofit.kt
+++ b/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/Retrofit.kt
@@ -22,9 +22,10 @@ internal fun buildRetrofit(
     client: OkHttpClient,
     moshi: Moshi,
 ) = with(Retrofit.Builder()) {
-    val url = options.gradleEnterpriseInstance.url()
-    check("/api" !in url) { "Instance URL must be the plain instance URL, without /api" }
-    baseUrl(url)
+    val apiUrl = options.gradleEnterpriseInstance.url()
+    check("/api/" in apiUrl) { "A valid API URL must end in /api/" }
+    val instanceUrl = apiUrl.substringBefore("api/")
+    baseUrl(instanceUrl)
     addConverterFactory(ScalarsConverterFactory.create())
     addConverterFactory(MoshiConverterFactory.create(moshi))
     client(client)

--- a/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/OptionsTest.kt
+++ b/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/OptionsTest.kt
@@ -12,11 +12,20 @@ import kotlin.test.assertTrue
 class OptionsTest {
 
     @Test
-    fun `URL from env is required`() {
+    fun `Given no URL set in env, url() fails`() {
         val options = Options(FakeEnv(), FakeKeychain())
         assertFails {
             options.gradleEnterpriseInstance.url()
         }
+    }
+
+    @Test
+    fun `Given URL set in env, url() returns env URL`() {
+        val options = Options(
+            FakeEnv("GRADLE_ENTERPRISE_API_URL" to "https://example.com/api/"),
+            FakeKeychain(),
+        )
+        assertEquals("https://example.com/api/", options.gradleEnterpriseInstance.url())
     }
 
     @Test

--- a/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/RetrofitTest.kt
+++ b/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/RetrofitTest.kt
@@ -15,10 +15,11 @@ import kotlin.test.*
 class RetrofitTest {
 
     @Test
-    fun `Sets URL from options`() {
+    fun `Sets instance URL from options, stripping api segment`() {
         val retrofit = buildRetrofit(
-            "GRADLE_ENTERPRISE_URL" to "https://example.com/",
+            "GRADLE_ENTERPRISE_API_URL" to "https://example.com/api/",
         )
+        // That's what generated classes expect
         assertEquals("https://example.com/", retrofit.baseUrl().toString())
     }
 
@@ -26,7 +27,7 @@ class RetrofitTest {
     fun `Rejects invalid URL`() {
         assertFails {
             buildRetrofit(
-                "GRADLE_ENTERPRISE_URL" to "https://example.com/api/",
+                "GRADLE_ENTERPRISE_API_URL" to "https://example.com/",
             )
         }
     }
@@ -37,8 +38,6 @@ class RetrofitTest {
         val env = FakeEnv(*envVars)
         if ("GRADLE_ENTERPRISE_API_TOKEN" !in env)
             env["GRADLE_ENTERPRISE_API_TOKEN"] = "example-token"
-        if ("GRADLE_ENTERPRISE_URL" !in env)
-            env["GRADLE_ENTERPRISE_URL"] = "example-url"
         val options = Options(env, FakeKeychain())
         return buildRetrofit(
             options = options,


### PR DESCRIPTION
The current name conflicts with the one used in https://github.com/gradle/common-custom-user-data-gradle-plugin. While they could remain the same, it's more flexible to use a different variable.