### PR TITLE
Always run all PR checks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,16 +14,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Check for modified code
-        id: diff
-        uses: tj-actions/changed-files@v35
-        with:
-          files: |
-            **/src/**
-            **/*.gradle*
-            ./gradle/*
       - name: gradle check
-        if: ${{ steps.diff.outputs.all_modified_files }}
         uses: ./.github/actions/build
         with:
           args: 'check'
@@ -35,18 +26,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Check for modified code
-        id: diff
-        uses: tj-actions/changed-files@v35
-        with:
-          files: |
-            **/*.py
       - name: 'unittest discover'
-        if: ${{ steps.diff.outputs.all_modified_files }}
         run: python3 -m unittest discover -bs .github/scripts
 
   readme-links-test:
-    needs: [choose-dry-runs]
     uses: ./.github/workflows/test-readme-links.yml
 
   generated-api-diff:
@@ -56,39 +39,27 @@ jobs:
     steps:
       - name: Checkout PR ref
         uses: actions/checkout@v3
-      - name: Check for modified code
-        id: git-diff
-        uses: tj-actions/changed-files@v35
-        with:
-          files: |
-            **/*.gradle*
       - name: gradle openApiGenerate (PR ref)
-        if: ${{ steps.git-diff.outputs.all_modified_files }}
         uses: ./.github/actions/build
         with:
           args: 'openApiGenerate'
       - run: mv ./build/generated/openapi-generator ./pr-ref-api
       - name: Checkout base ref
-        if: ${{ steps.git-diff.outputs.all_modified_files }}
         uses: actions/checkout@v3
         with:
           path: ./base-ref-checkout
           ref: ${{ github.base_ref }}
       - name: gradle openApiGenerate (base ref)
-        if: ${{ steps.git-diff.outputs.all_modified_files }}
         uses: ./.github/actions/build
         with:
           args: '-p ./base-ref-checkout openApiGenerate'
       - run: mv ./base-ref-checkout/build/generated/openapi-generator ./base-ref-api
-        if: ${{ steps.git-diff.outputs.all_modified_files }}
       - name: Diff generated APIs
-        if: ${{ steps.git-diff.outputs.all_modified_files }}
         run: |
           echo -e '### Generated API diff\n\n```diff' > comment.md
           diff -ur ./base-ref-api ./pr-ref-api | tee -a comment.md || true
           echo -e '```' >> comment.md
       - name: Find existing comment
-        if: ${{ steps.git-diff.outputs.all_modified_files }}
         uses: peter-evans/find-comment@v2
         id: find-comment
         with:
@@ -96,7 +67,6 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-includes: 'Generated API diff'
       - name: Create or update diff comment
-        if: ${{ steps.git-diff.outputs.all_modified_files }}
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -104,43 +74,12 @@ jobs:
           body-file: 'comment.md'
           edit-mode: replace
 
-  choose-dry-runs:
-    runs-on: ubuntu-latest
-    outputs:
-      dry-run-publish-javadoc: ${{ steps.diff-publish-javadoc.outputs.all_modified_files }}
-      dry-run-check-new-api-spec: ${{ steps.diff-check-new-api-spec.outputs.all_modified_files }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Diff publish-javadoc.yml
-        id: diff-publish-javadoc
-        uses: tj-actions/changed-files@v35
-        with:
-          files: |
-            .github/workflows/publish-javadoc.yml
-            .github/scripts/*
-            **/src/**
-            **/*.gradle*
-            ./gradle/*
-      - name: Diff check-new-api-spec.yml
-        id: diff-check-new-api-spec
-        uses: tj-actions/changed-files@v35
-        with:
-          files: |
-            .github/workflows/check-new-api-spec.yml
-            .github/scripts/*
-            gradle.properties
-
   dry-run-publish-javadoc:
-    needs: [choose-dry-runs]
-    if: ${{ needs.choose-dry-runs.outputs.dry-run-publish-javadoc }}
     uses: ./.github/workflows/publish-javadoc.yml
     with:
       dry_run: true
 
   dry-run-check-new-api-spec:
-    needs: [choose-dry-runs]
-    if: ${{ needs.choose-dry-runs.outputs.dry-run-check-new-api-spec }}
     uses: ./.github/workflows/check-new-api-spec.yml
     with:
       dry_run: true


### PR DESCRIPTION
Simplify PR workflow by always running all checks, without checking which files changed. The benefits at this scale aren't worth risk of a check not running when it should.