### PR TITLE
Enable consistent resolution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,6 +116,12 @@ testing {
     }
 }
 
+java {
+    consistentResolution {
+        useRuntimeClasspathVersions()
+    }
+}
+
 dependencies {
     api("com.squareup.moshi:moshi:1.14.0")
     implementation("com.squareup.moshi:moshi-kotlin:1.14.0")
@@ -125,6 +131,6 @@ dependencies {
     implementation("com.squareup.retrofit2:converter-scalars:2.9.0")
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
-    testImplementation("com.squareup.okio:okio:3.3.0")
+    testImplementation("com.squareup.okio:okio:3.0.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
 }


### PR DESCRIPTION
Enable consistent resolution with runtimeClasspath. 

Checking for inconsistent versions with [this script][1] shows Okio version was inconsistent:

```
project ':': inconsistencies found
  com.squareup.okio:okio:
    3.0.0 (compileClasspath)
    3.0.0 (runtimeClasspath)
    3.3.0 (testCompileClasspath)
    3.3.0 (testRuntimeClasspath)
  com.squareup.okio:okio-jvm:
    3.0.0 (compileClasspath)
    3.0.0 (runtimeClasspath)
    3.3.0 (testCompileClasspath)
    3.3.0 (testRuntimeClasspath)
```

Since Okio is only a transitive dependency except in tests, downgrade tests to use 3.0.0.

[1]: https://gist.github.com/gabrielfeo/9d32a23a3dcb71bc19b9914e5761939d#file-check-inconsistent-versions-init-gradle-kts