### PR TITLE
Fix API spec update workflow

### DIFF
--- a/.github/scripts/test_resources/api_manual.html
+++ b/.github/scripts/test_resources/api_manual.html
@@ -1,0 +1,366 @@
+
+<!doctype html>
+<html lang="en">
+ <head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="generator" content="Asciidoctor 2.0.10">
+  <title>Gradle Enterprise API User Manual | Gradle Enterprise Docs</title>
+  <script src="/cdn-cgi/apps/head/x8dPp8IIVB0yHdALlVNjXfOS4f8.js"></script><link rel="stylesheet" href="css/asciidoctor.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+  <meta name="theme-color" content="#02303A">
+  <meta name="code-samples-storage-name" content="preferred-gradle-dsl">
+  <meta name="code-samples-sorted-dsls" content="groovy,kotlin"> <!-- favicon -->
+  <link rel="manifest" href="https://assets.gradle.com/icon/gradle-enterprise/site.webmanifest">
+  <link rel="icon" href="https://assets.gradle.com/icon/gradle-enterprise/favicon.ico">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://assets.gradle.com/icon/gradle-enterprise/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://assets.gradle.com/icon/gradle-enterprise/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://assets.gradle.com/icon/gradle-enterprise/apple-touch-icon.png">
+  <link rel="stylesheet" href="https://assets.gradle.com/lato/css/lato-font.css">
+  <link rel="stylesheet" href="https://assets.gradle.com/inconsolata/inconsolata.css">
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+  <script type="text/javascript" src="js/setup-highlighting.js"></script>
+  <script type="text/javascript" src="js/html-passthrough.js"></script>
+  <script type="text/javascript" src="js/code-samples.js"></script>
+  <script type="text/javascript" src="js/prompt-prefix-fix.js"></script>
+  <script type="text/javascript" src="js/copy-button.js"></script>
+  <script type="text/javascript">
+  function adjustTOC() {
+    var tocLinks = $('#toc').find('a');
+    var tocLinkHrefs = tocLinks.map(function() { return $(this).attr("href") }).get();
+
+    var activeHref;
+    var scrollTop = (document.documentElement.scrollTop || document.body.scrollTop);
+    $('#content').find('a.anchor').each(function() {
+      var link = $(this);
+      var href = link.attr("href");
+      if ($.inArray(href, tocLinkHrefs) != -1) {
+        if (activeHref == null || Math.floor(link.offset().top) <= scrollTop) {
+          activeHref = href;
+        } else {
+          return false;
+        }
+      }
+    });
+    tocLinks.filter(".active[href!='" + activeHref + "']").removeClass("active");
+    tocLinks.filter("[href='" + activeHref + "']").addClass("active");
+  }
+
+  $(window).scroll(adjustTOC).click(adjustTOC);
+  $(adjustTOC);
+</script>
+ </head>
+ <body class="article toc2 toc-right">
+  <div id="header">
+   <div style="padding-top: 10px;">
+    <a href="https://gradle.com" alt="Gradlephant">
+     <svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" width="278px" height="43px" viewbox="160 0 278 86">
+      <title>Gradle Enterprise</title> <path fill="#02303a" d="M148.76,52.31v14a18.29,18.29,0,0,1-5.59,2.82,21.82,21.82,0,0,1-6.36.9,21.08,21.08,0,0,1-7.64-1.32A17,17,0,0,1,123.33,65a15.85,15.85,0,0,1-3.74-5.58,18.78,18.78,0,0,1-1.31-7.08,19.32,19.32,0,0,1,1.27-7.13,16,16,0,0,1,3.58-5.58A16.16,16.16,0,0,1,128.78,36a20.37,20.37,0,0,1,7.44-1.29,21,21,0,0,1,3.92.34,20.43,20.43,0,0,1,3.39.91,15.16,15.16,0,0,1,2.85,1.42,17.3,17.3,0,0,1,2.36,1.84l-1.84,2.91a1.77,1.77,0,0,1-1.12.85,2,2,0,0,1-1.5-.35l-1.57-.91A10.16,10.16,0,0,0,141,41a14,14,0,0,0-2.17-.55,16.24,16.24,0,0,0-2.78-.22,11.91,11.91,0,0,0-4.61.86,9.78,9.78,0,0,0-3.52,2.46,11.08,11.08,0,0,0-2.24,3.84,14.92,14.92,0,0,0-.79,5,15.23,15.23,0,0,0,.85,5.28,11.2,11.2,0,0,0,2.38,3.94A10.15,10.15,0,0,0,131.78,64a14.42,14.42,0,0,0,8.25.45,16.84,16.84,0,0,0,2.94-1.1V57.13h-4.34a1.31,1.31,0,0,1-1-.35,1.14,1.14,0,0,1-.34-.84V52.31Zm10.48-2.93A10.48,10.48,0,0,1,162,45.93a5.83,5.83,0,0,1,3.73-1.25,4.55,4.55,0,0,1,2.71.74L168,49.83a1.14,1.14,0,0,1-.34.61,1,1,0,0,1-.61.18A6.89,6.89,0,0,1,166,50.5a8.19,8.19,0,0,0-1.37-.12,5,5,0,0,0-1.75.29,4.46,4.46,0,0,0-1.37.82,5.76,5.76,0,0,0-1.07,1.3,12.82,12.82,0,0,0-.87,1.74V69.6h-5.89V45.13h3.46a1.93,1.93,0,0,1,1.26.32,1.9,1.9,0,0,1,.48,1.16Zm11.35-.84a14.53,14.53,0,0,1,10.16-3.86,9.92,9.92,0,0,1,3.84.7,8.06,8.06,0,0,1,2.86,2,8.38,8.38,0,0,1,1.78,3,11.42,11.42,0,0,1,.61,3.82V69.6h-2.67a2.66,2.66,0,0,1-1.29-.25,1.73,1.73,0,0,1-.72-1l-.52-1.77A21.7,21.7,0,0,1,182.83,68,10.66,10.66,0,0,1,181,69.1a9.74,9.74,0,0,1-2,.66,11.78,11.78,0,0,1-2.4.23,9.32,9.32,0,0,1-2.86-.42,6.5,6.5,0,0,1-2.27-1.25,5.72,5.72,0,0,1-1.48-2.08,7.36,7.36,0,0,1-.52-2.88,5.53,5.53,0,0,1,1.32-3.61,8.52,8.52,0,0,1,1.83-1.57,12.15,12.15,0,0,1,2.75-1.29,24.42,24.42,0,0,1,3.81-.89,38.51,38.51,0,0,1,5-.42V54.15A5.36,5.36,0,0,0,183,50.51a3.83,3.83,0,0,0-3-1.18,7.28,7.28,0,0,0-2.37.33,10.29,10.29,0,0,0-1.66.76l-1.3.75a2.59,2.59,0,0,1-1.3.33,1.74,1.74,0,0,1-1-.32,2.71,2.71,0,0,1-.69-.75Zm13.5,10.62a31.67,31.67,0,0,0-4.29.44,11.3,11.3,0,0,0-2.79.82,3.69,3.69,0,0,0-1.51,1.17,2.89,2.89,0,0,0,.47,3.67,3.93,3.93,0,0,0,2.39.67,7.09,7.09,0,0,0,3.14-.65,9.42,9.42,0,0,0,2.59-2Zm32.53-25V69.6H213a1.38,1.38,0,0,1-1.48-1.07l-.5-2.36a12.25,12.25,0,0,1-3.4,2.74,9.17,9.17,0,0,1-4.47,1,8.14,8.14,0,0,1-3.67-.83,8.32,8.32,0,0,1-2.88-2.42,11.76,11.76,0,0,1-1.86-3.93,19.67,19.67,0,0,1-.65-5.34,16.51,16.51,0,0,1,.74-5.06A12.3,12.3,0,0,1,197,48.33a9.82,9.82,0,0,1,3.31-2.68,9.53,9.53,0,0,1,4.35-1,8.61,8.61,0,0,1,3.5.64,9,9,0,0,1,2.6,1.74V34.16Zm-5.89,17.22a5.87,5.87,0,0,0-2.18-1.72,6.5,6.5,0,0,0-2.54-.5,5.71,5.71,0,0,0-2.41.5,4.87,4.87,0,0,0-1.84,1.52,7.34,7.34,0,0,0-1.17,2.58,14.74,14.74,0,0,0-.4,3.68,16.5,16.5,0,0,0,.34,3.64,7.6,7.6,0,0,0,1,2.43,3.79,3.79,0,0,0,1.58,1.36,5,5,0,0,0,2.07.42,6,6,0,0,0,3.13-.77,9,9,0,0,0,2.43-2.17Zm17.68-17.22V69.6h-5.9V34.16Zm10.42,24a11.72,11.72,0,0,0,.67,3.25,6.69,6.69,0,0,0,1.38,2.27,5.41,5.41,0,0,0,2,1.34,7.52,7.52,0,0,0,2.61.44,7.84,7.84,0,0,0,2.47-.34,11.13,11.13,0,0,0,1.81-.74c.52-.27,1-.51,1.36-.74a2.31,2.31,0,0,1,1.14-.33,1.2,1.2,0,0,1,1.09.55L255.1,66a9.91,9.91,0,0,1-2.2,1.91,12,12,0,0,1-2.54,1.25,14.06,14.06,0,0,1-2.69.65A18.92,18.92,0,0,1,245,70a13.18,13.18,0,0,1-4.75-.84,10.76,10.76,0,0,1-3.82-2.51,11.7,11.7,0,0,1-2.55-4.1,15.9,15.9,0,0,1-.93-5.67,13.55,13.55,0,0,1,.81-4.71,11.34,11.34,0,0,1,2.33-3.84,11,11,0,0,1,3.7-2.59,12.23,12.23,0,0,1,4.92-1,12,12,0,0,1,4.27.74,9.17,9.17,0,0,1,3.36,2.16,10,10,0,0,1,2.21,3.48,13.06,13.06,0,0,1,.8,4.71,3.82,3.82,0,0,1-.29,1.8,1.17,1.17,0,0,1-1.09.47Zm11.23-3.56a7,7,0,0,0-.32-2.16,5.06,5.06,0,0,0-1-1.77,4.59,4.59,0,0,0-1.64-1.21,5.68,5.68,0,0,0-2.3-.44,5.47,5.47,0,0,0-4,1.46A7.1,7.1,0,0,0,239,54.55Zm43.65,13,0,2H273.44V35.85h20.23v2H275.9V51.52h14.78v2H275.9V67.58ZM301.37,50a13.47,13.47,0,0,1,3.8-3.29A9.47,9.47,0,0,1,310,45.49a9,9,0,0,1,3.45.62,6.38,6.38,0,0,1,2.47,1.79,7.92,7.92,0,0,1,1.47,2.81,12.58,12.58,0,0,1,.51,3.72V69.6h-2.29V54.43a8.1,8.1,0,0,0-1.53-5.23,5.63,5.63,0,0,0-4.65-1.9,8.49,8.49,0,0,0-4.33,1.18,12.19,12.19,0,0,0-3.59,3.28V69.6H299.2V45.87h1.26a.63.63,0,0,1,.69.6Zm30.24,20a5.1,5.1,0,0,1-3.75-1.34,5.6,5.6,0,0,1-1.35-4.13V48.3H323.1a.6.6,0,0,1-.43-.14.5.5,0,0,1-.17-.4v-.89l4.06-.28.57-8.49a1,1,0,0,1,.19-.39.51.51,0,0,1,.41-.16h1.07v9.06h7.49V48.3H328.8V64.41a5,5,0,0,0,.25,1.68,3.18,3.18,0,0,0,.69,1.15,2.63,2.63,0,0,0,1,.67,4.12,4.12,0,0,0,2.77,0,5.62,5.62,0,0,0,1.07-.54,6.78,6.78,0,0,0,.74-.55.79.79,0,0,1,.45-.25.5.5,0,0,1,.38.24l.62,1a6.6,6.6,0,0,1-2.3,1.61A7.25,7.25,0,0,1,331.61,70ZM342.2,56.8v.45a15.87,15.87,0,0,0,.63,4.7,9.69,9.69,0,0,0,1.76,3.4,7.22,7.22,0,0,0,2.77,2.06,9.16,9.16,0,0,0,3.62.69,10.88,10.88,0,0,0,3.1-.39,11.8,11.8,0,0,0,2.21-.88,11.31,11.31,0,0,0,1.42-.89,1.61,1.61,0,0,1,.76-.39.55.55,0,0,1,.48.24l.62.76a6.53,6.53,0,0,1-1.52,1.34A11.05,11.05,0,0,1,356,69a15.54,15.54,0,0,1-2.48.7,13.35,13.35,0,0,1-2.67.26,11.32,11.32,0,0,1-4.43-.84,9.52,9.52,0,0,1-3.44-2.47,11.22,11.22,0,0,1-2.2-4,17.07,17.07,0,0,1-.78-5.38,14.54,14.54,0,0,1,.73-4.71,10.59,10.59,0,0,1,2.1-3.72,9.55,9.55,0,0,1,3.36-2.45,11,11,0,0,1,4.52-.88,9.85,9.85,0,0,1,3.72.69,8.25,8.25,0,0,1,3,2,9.4,9.4,0,0,1,2,3.25,12.68,12.68,0,0,1,.72,4.44,1.26,1.26,0,0,1-.14.72.57.57,0,0,1-.48.19ZM358,55.34a10.4,10.4,0,0,0-.53-3.42A7.36,7.36,0,0,0,356,49.35a6.72,6.72,0,0,0-2.32-1.61,7.74,7.74,0,0,0-3-.56,8.79,8.79,0,0,0-3.3.58,7.15,7.15,0,0,0-2.51,1.64A8.3,8.3,0,0,0,343.18,52a12.17,12.17,0,0,0-.86,3.36Zm10.4-3.74A14.86,14.86,0,0,1,369.7,49a7.64,7.64,0,0,1,1.62-1.92,6.53,6.53,0,0,1,2.05-1.21,7.38,7.38,0,0,1,2.51-.41,7.85,7.85,0,0,1,1.46.13,3.5,3.5,0,0,1,1.26.46l-.19,1.58A.46.46,0,0,1,378,48a3.65,3.65,0,0,1-.87-.17,5.8,5.8,0,0,0-1.54-.17,6.56,6.56,0,0,0-2.44.42,5.7,5.7,0,0,0-1.91,1.25,7.94,7.94,0,0,0-1.48,2.07,19.85,19.85,0,0,0-1.16,2.82V69.6h-2.29V45.87h1.22a.79.79,0,0,1,.57.17,1,1,0,0,1,.22.57Zm16.89-1.46A12.63,12.63,0,0,1,389,46.73a9.08,9.08,0,0,1,4.74-1.26,8.26,8.26,0,0,1,6.81,3q2.44,3,2.44,9.08a16.55,16.55,0,0,1-.68,4.86,11.57,11.57,0,0,1-2,3.91A9.59,9.59,0,0,1,397.08,69a9.79,9.79,0,0,1-4.43,1,9.19,9.19,0,0,1-4.17-.88,8.59,8.59,0,0,1-3.06-2.6V78h-2.28V45.87h1.26a.63.63,0,0,1,.69.6Zm.09,14.29a10.76,10.76,0,0,0,1.45,1.73,7.25,7.25,0,0,0,1.58,1.14,6.53,6.53,0,0,0,1.78.64,10.58,10.58,0,0,0,2,.19,8.34,8.34,0,0,0,3.68-.77,7.25,7.25,0,0,0,2.63-2.16,9.69,9.69,0,0,0,1.6-3.34,15.92,15.92,0,0,0,.54-4.28c0-3.53-.66-6.12-2-7.78a6.68,6.68,0,0,0-5.61-2.5,7.76,7.76,0,0,0-4.26,1.22,12.09,12.09,0,0,0-3.42,3.39ZM411.61,51.6A14.86,14.86,0,0,1,412.87,49a7.85,7.85,0,0,1,1.62-1.92,6.53,6.53,0,0,1,2.05-1.21,7.44,7.44,0,0,1,2.52-.41,7.82,7.82,0,0,1,1.45.13,3.62,3.62,0,0,1,1.27.46l-.2,1.58a.46.46,0,0,1-.45.38,3.65,3.65,0,0,1-.87-.17,5.8,5.8,0,0,0-1.54-.17,6.56,6.56,0,0,0-2.44.42,5.7,5.7,0,0,0-1.91,1.25,7.94,7.94,0,0,0-1.48,2.07,19.85,19.85,0,0,0-1.16,2.82V69.6h-2.29V45.87h1.22a.79.79,0,0,1,.57.17,1,1,0,0,1,.22.57Zm18.2-13.91a1.8,1.8,0,0,1-.18.8,2.52,2.52,0,0,1-.46.66,2.19,2.19,0,0,1-.67.45,2.13,2.13,0,0,1-1.62,0,2.08,2.08,0,0,1-.67-.45,2.27,2.27,0,0,1-.45-.66,1.94,1.94,0,0,1-.17-.8,2.08,2.08,0,0,1,.17-.82,2.12,2.12,0,0,1,.45-.68,2.28,2.28,0,0,1,.67-.46,2.13,2.13,0,0,1,1.62,0,2.42,2.42,0,0,1,.67.46,2.33,2.33,0,0,1,.46.68A1.92,1.92,0,0,1,429.81,37.69Zm-1,8.18V69.6h-2.27V45.87ZM450,48.81a.6.6,0,0,1-.55.33,1.23,1.23,0,0,1-.67-.3,10.17,10.17,0,0,0-1.08-.67,8.9,8.9,0,0,0-1.69-.66,8.48,8.48,0,0,0-2.43-.3,7,7,0,0,0-2.35.37,5.53,5.53,0,0,0-1.81,1A4.32,4.32,0,0,0,438.23,50a3.88,3.88,0,0,0-.4,1.73,3,3,0,0,0,.57,1.86,5,5,0,0,0,1.49,1.26,10.8,10.8,0,0,0,2.11.91l2.42.76c.82.26,1.63.54,2.42.85A8.7,8.7,0,0,1,449,58.54a5.37,5.37,0,0,1,1.49,1.69,4.75,4.75,0,0,1,.58,2.43,7.63,7.63,0,0,1-.55,2.89,6.43,6.43,0,0,1-1.61,2.31,7.67,7.67,0,0,1-2.61,1.55,10.07,10.07,0,0,1-3.56.58,10.63,10.63,0,0,1-4.31-.8,12.38,12.38,0,0,1-3.25-2.09l.53-.81a1,1,0,0,1,.27-.29.82.82,0,0,1,.42-.09,1.26,1.26,0,0,1,.75.38,8.4,8.4,0,0,0,1.18.82,10.09,10.09,0,0,0,1.82.83,8.33,8.33,0,0,0,2.69.38,7.72,7.72,0,0,0,2.65-.42,5.64,5.64,0,0,0,1.9-1.13,4.69,4.69,0,0,0,1.16-1.69,5.37,5.37,0,0,0,.39-2,3.26,3.26,0,0,0-.57-2,4.88,4.88,0,0,0-1.5-1.34,10,10,0,0,0-2.11-.93L442.29,58c-.83-.26-1.64-.54-2.42-.84a9,9,0,0,1-2.12-1.14,5.64,5.64,0,0,1-1.5-1.69,4.84,4.84,0,0,1-.57-2.46,5.61,5.61,0,0,1,.55-2.44,6.05,6.05,0,0,1,1.56-2A7.71,7.71,0,0,1,440.26,46a9.84,9.84,0,0,1,3.27-.52,11.18,11.18,0,0,1,3.85.62A9,9,0,0,1,450.44,48Zm8,8v.45a15.89,15.89,0,0,0,.62,4.7,9.69,9.69,0,0,0,1.76,3.4,7.3,7.3,0,0,0,2.77,2.06,9.16,9.16,0,0,0,3.62.69,10.88,10.88,0,0,0,3.1-.39,11.8,11.8,0,0,0,2.21-.88,11.31,11.31,0,0,0,1.42-.89,1.61,1.61,0,0,1,.76-.39.55.55,0,0,1,.48.24l.62.76a6.53,6.53,0,0,1-1.52,1.34A11.05,11.05,0,0,1,471.76,69a15.54,15.54,0,0,1-2.48.7,13.32,13.32,0,0,1-2.66.26,11.33,11.33,0,0,1-4.44-.84,9.52,9.52,0,0,1-3.44-2.47,11.22,11.22,0,0,1-2.2-4,17.07,17.07,0,0,1-.78-5.38,14.54,14.54,0,0,1,.73-4.71,10.75,10.75,0,0,1,2.1-3.72A9.55,9.55,0,0,1,462,46.37a11,11,0,0,1,4.52-.88,9.85,9.85,0,0,1,3.72.69,8.25,8.25,0,0,1,3,2,9.4,9.4,0,0,1,2,3.25,12.68,12.68,0,0,1,.72,4.44,1.26,1.26,0,0,1-.14.72.57.57,0,0,1-.48.19Zm15.83-1.46a10.4,10.4,0,0,0-.53-3.42,7.36,7.36,0,0,0-1.52-2.57,6.72,6.72,0,0,0-2.32-1.61,7.74,7.74,0,0,0-3-.56,8.79,8.79,0,0,0-3.3.58,7.33,7.33,0,0,0-2.51,1.64A8.3,8.3,0,0,0,459,52a12.17,12.17,0,0,0-.86,3.36ZM106,10A13.74,13.74,0,0,0,86.91,9.7a1.27,1.27,0,0,0-.41.93,1.29,1.29,0,0,0,.38.95l1.73,1.73a1.31,1.31,0,0,0,1.71.12A7.87,7.87,0,0,1,100.6,25.3C89.7,36.2,75.14,5.65,42.13,21.36a4.48,4.48,0,0,0-2,6.29l5.67,9.8a4.47,4.47,0,0,0,6.06,1.66L52,39l-.11.08,2.51-1.4a58.26,58.26,0,0,0,7.91-5.9,1.38,1.38,0,0,1,1.8-.06h0a1.3,1.3,0,0,1,.06,2A58.84,58.84,0,0,1,55.84,40l-.09,0-2.51,1.41a7.2,7.2,0,0,1-9.7-2.67l-5.36-9.24C27.9,36.81,21.67,50.8,25,68.49a1.3,1.3,0,0,0,1.28,1.07h6.09a1.32,1.32,0,0,0,1.3-1.15,8.93,8.93,0,0,1,17.72,0,1.31,1.31,0,0,0,1.29,1.15h5.94a1.32,1.32,0,0,0,1.3-1.15,8.93,8.93,0,0,1,17.72,0A1.31,1.31,0,0,0,79,69.56h5.87a1.32,1.32,0,0,0,1.31-1.29c.13-8.28,2.36-17.78,8.73-22.55C116.89,29.24,111.09,15.12,106,10ZM83.52,34.91l-4.2-2.11h0a2.64,2.64,0,1,1,4.2,2.12Z" />
+     </svg> </a>
+   </div>
+   <h1>Gradle Enterprise API User Manual</h1>
+   <div id="toc" class="toc2">
+    <div id="toctitle">
+     Table of Contents
+    </div>
+    <ul class="sectlevel1">
+     <li><a href="#fundamentals">Fundamentals</a>
+      <ul class="sectlevel2">
+       <li><a href="#openapi">OpenAPI</a></li>
+       <li><a href="#versioning_and_compatibility">Versioning and compatibility</a></li>
+      </ul> </li>
+     <li><a href="#getting_started">Getting started</a>
+      <ul class="sectlevel2">
+       <li><a href="#access_control">Access control</a></li>
+       <li><a href="#making_a_request">Making a request</a></li>
+       <li><a href="#next_steps">Next steps</a></li>
+      </ul> </li>
+     <li><a href="#reference_documentation">Reference</a>
+      <ul class="sectlevel2">
+       <li><a href="#2023_1">2023.1</a></li>
+       <li><a href="#older_versions">Older Versions</a></li>
+      </ul> </li>
+     <li><a href="#about_the_export_api">Appendix A: About the Export API</a></li>
+     <li><a href="#release_history">Appendix B: Release history</a></li>
+    </ul>
+   </div>
+  </div>
+  <div id="content">
+   <div id="preamble">
+    <div class="sectionbody">
+     <div class="paragraph">
+      <p>The Gradle Enterprise API allows programmatic interaction with various aspects of Gradle Enterprise, from configuration to inspecting build data.</p>
+     </div>
+    </div>
+   </div>
+   <div class="sect1">
+    <h2 id="fundamentals"><a class="anchor" href="#fundamentals"></a><a class="link" href="#fundamentals">Fundamentals</a></h2>
+    <div class="sectionbody">
+     <div class="paragraph">
+      <p>The Gradle Enterprise API is a REST-style API using JSON as the data format.</p>
+     </div>
+     <div class="sect2">
+      <h3 id="openapi"><a class="anchor" href="#openapi"></a><a class="link" href="#openapi">OpenAPI</a></h3>
+      <div class="paragraph">
+       <p>The API is defined using the <a href="https://www.openapis.org">OpenAPI standard</a>, which is a declarative specification that allows <a href="https://github.com/OAI/OpenAPI-Specification/blob/main/IMPLEMENTATIONS.md">tools and libraries</a> to generate client code. The specification can be found in the <a href="#reference_documentation">Reference</a> section.</p>
+      </div>
+     </div>
+     <div class="sect2">
+      <h3 id="versioning_and_compatibility"><a class="anchor" href="#versioning_and_compatibility"></a><a class="link" href="#versioning_and_compatibility">Versioning and compatibility</a></h3>
+      <div class="paragraph">
+       <p>The API is generally backwards compatible.</p>
+      </div>
+      <div class="paragraph">
+       <p>New functionality (e.g. endpoints, response attributes) may be added in new major versions (i.e. 2022.1, 2022.2).</p>
+      </div>
+      <div class="paragraph">
+       <p>Breaking changes will occur infrequently if at all, and only after a reasonable deprecation period. Deprecations will be communicated by:</p>
+      </div>
+      <div class="ulist">
+       <ul>
+        <li> <p>The release notes for the major Gradle Enterprise version introducing the deprecation.</p> </li>
+        <li> <p>The <code><a href="https://spec.openapis.org/oas/latest.html#operationDeprecated">deprecated</a></code> annotation within the OpenAPI specification.</p> </li>
+        <li> <p>The <code><a href="https://tools.ietf.org/id/draft-dalal-deprecation-header-01.html">Deprecated</a></code> HTTP response header (indicating when the operation was deprecated).</p> </li>
+        <li> <p>The <code><a href="https://datatracker.ietf.org/doc/html/rfc8594">Sunset</a></code> HTTP response header (indicating when the operation will be removed).</p> </li>
+       </ul>
+      </div>
+      <div class="paragraph">
+       <p>API documentation may be refined in patch releases, along with implementation defects that cause deviation from the specification.</p>
+      </div>
+     </div>
+    </div>
+   </div>
+   <div class="sect1">
+    <h2 id="getting_started"><a class="anchor" href="#getting_started"></a><a class="link" href="#getting_started">Getting started</a></h2>
+    <div class="sectionbody">
+     <div class="sect2">
+      <h3 id="access_control"><a class="anchor" href="#access_control"></a><a class="link" href="#access_control">Access control</a></h3>
+      <div class="paragraph">
+       <p>All requests must provide a Gradle Enterprise access key as “bearer token”.</p>
+      </div>
+      <div class="paragraph">
+       <p>To create an access key:</p>
+      </div>
+      <div class="olist arabic">
+       <ol class="arabic">
+        <li> <p>Sign in to Gradle Enterprise.</p> </li>
+        <li> <p>Access "My settings" from the user menu in the top right-hand corner of the page.</p> </li>
+        <li> <p>Access "Access keys" from the left-hand menu.</p> </li>
+        <li> <p>Click "Generate" on the right-hand side and copy the generated access key.</p> </li>
+       </ol>
+      </div>
+      <div class="paragraph">
+       <p>Different requests require different user permissions, as describe via the API specification.</p>
+      </div>
+      <div class="paragraph">
+       <p>To view the permissions assigned to you:</p>
+      </div>
+      <div class="olist arabic">
+       <ol class="arabic">
+        <li> <p>Sign in to Gradle Enterprise.</p> </li>
+        <li> <p>Access "My settings" from the user menu in the top right-hand corner of the page.</p> </li>
+        <li> <p>Access "Permissions" from the left-hand menu.</p> </li>
+        <li> <p>Check if you have the required permissions.</p> </li>
+       </ol>
+      </div>
+      <div class="paragraph">
+       <p>If you do not have the required permission, contact your Gradle Enterprise administrator.</p>
+      </div>
+     </div>
+     <div class="sect2">
+      <h3 id="making_a_request"><a class="anchor" href="#making_a_request"></a><a class="link" href="#making_a_request">Making a request</a></h3>
+      <div class="paragraph">
+       <p>The following example demonstrates using <a href="http://curl.haxx.se"><code>cURL</code></a> to make a request to the <code>builds</code> endpoint, which requires the “Access build data via the API” permission.</p>
+      </div>
+      <div class="listingblock">
+       <div class="content">
+        <pre class="highlightjs highlight"><code class="language-none hljs">$ curl -H "Authorization: Bearer 7asejatf24zun43yshqufp7qi4ovcefxpykbwzqbzilcpwzb52ja" "https://ge.mycompany.com/api/builds?since=0&amp;maxBuilds=3"</code></pre>
+       </div>
+      </div>
+      <div class="listingblock">
+       <div class="content">
+        <pre>[
+  {
+    "id": "7asfp6iy3d5ey",
+    "availableAt": 1645452789334,
+    "buildToolType": "gradle",
+    "buildToolVersion": "7.4",
+    "buildAgentVersion": "3.8.1"
+  },
+  {
+    "id": "1saxebtd5d4xs",
+    "availableAt": 1645452795414,
+    "buildToolType": "maven",
+    "buildToolVersion": "3.8.4",
+    "buildAgentVersion": "1.12.4"
+  },
+  {
+    "id": "hx4k23knk64ri",
+    "availableAt": 1645453205526,
+    "buildToolType": "gradle",
+    "buildToolVersion": "7.4",
+    "buildAgentVersion": "3.8.1"
+  }
+]</pre>
+       </div>
+      </div>
+      <div class="paragraph">
+       <p>The <code>builds</code> endpoint can be used to discover the builds observed by the system. This example fetches the 3 oldest builds due to the <code>since=0&amp;maxBuilds=3</code> parameters.</p>
+      </div>
+     </div>
+     <div class="sect2">
+      <h3 id="next_steps"><a class="anchor" href="#next_steps"></a><a class="link" href="#next_steps">Next steps</a></h3>
+      <div class="paragraph">
+       <p>Check out the <a href="https://github.com/gradle/gradle-enterprise-api-samples">sample project</a>.</p>
+      </div>
+      <div class="paragraph">
+       <p>To learn more about the functionality provided by the API and what you can do with it, see <a href="#reference_documentation">Reference</a>.</p>
+      </div>
+     </div>
+    </div>
+   </div>
+   <div class="sect1">
+    <h2 id="reference_documentation"><a class="anchor" href="#reference_documentation"></a><a class="link" href="#reference_documentation">Reference</a></h2>
+    <div class="sectionbody">
+     <div class="paragraph">
+      <p>The reference documentation is useful for discovering the functionality of the API.</p>
+     </div>
+     <div class="paragraph">
+      <p>The reference specification is the API described using the OpenAPI standard and is useful for generating client code with <a href="https://github.com/OAI/OpenAPI-Specification/blob/main/IMPLEMENTATIONS.md">OpenAPI-based tooling</a>.</p>
+     </div>
+     <div class="sect2">
+      <h3 id="2023_1"><a class="anchor" href="#2023_1"></a><a class="link" href="#2023_1">2023.1</a></h3>
+      <div class="ulist">
+       <ul>
+        <li> <p><a href="ref/2023.1.html">Documentation</a></p> </li>
+        <li> <p><a href="ref/gradle-enterprise-2023.1-api.yaml">Specification</a> (<a href="ref/gradle-enterprise-2023.1-api.yaml.sha256">SHA-256 checksum</a>, <a href="ref/gradle-enterprise-2023.1-api.yaml.asc">PGP signature</a>, <a href="ref/gradle-enterprise-2023.1-api.yaml.asc.sha256">PGP signature SHA-256 checksum</a>)</p> </li>
+       </ul>
+      </div>
+     </div>
+     <div class="sect2">
+      <h3 id="older_versions"><a class="anchor" href="#older_versions"></a><a class="link" href="#older_versions">Older Versions</a></h3>
+      <table class="tableblock frame-all grid-all stretch">
+       <colgroup>
+        <col style="width: 11.1111%;">
+        <col style="width: 22.2222%;">
+        <col style="width: 66.6667%;">
+       </colgroup>
+       <tbody>
+        <tr>
+         <td class="tableblock halign-left valign-top"><p class="tableblock">2022.4</p></td>
+         <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="ref/2022.4.html">Documentation</a></p></td>
+         <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="ref/gradle-enterprise-2022.4-api.yaml">Specification</a> (<a href="ref/gradle-enterprise-2022.4-api.yaml.sha256">SHA-256 checksum</a>, <a href="ref/gradle-enterprise-2022.4-api.yaml.asc">PGP signature</a>, <a href="ref/gradle-enterprise-2022.4-api.yaml.asc.sha256">PGP signature SHA-256 checksum</a>)</p></td>
+        </tr>
+        <tr>
+         <td class="tableblock halign-left valign-top"><p class="tableblock">2022.3</p></td>
+         <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="ref/2022.3.html">Documentation</a></p></td>
+         <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="ref/gradle-enterprise-2022.3-api.yaml">Specification</a> (<a href="ref/gradle-enterprise-2022.3-api.yaml.sha256">SHA-256 checksum</a>, <a href="ref/gradle-enterprise-2022.3-api.yaml.asc">PGP signature</a>, <a href="ref/gradle-enterprise-2022.3-api.yaml.asc.sha256">PGP signature SHA-256 checksum</a>)</p></td>
+        </tr>
+        <tr>
+         <td class="tableblock halign-left valign-top"><p class="tableblock">2022.2</p></td>
+         <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="ref/2022.2.html">Documentation</a></p></td>
+         <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="ref/gradle-enterprise-2022.2-api.yaml">Specification</a> (<a href="ref/gradle-enterprise-2022.2-api.yaml.sha256">SHA-256 checksum</a>, <a href="ref/gradle-enterprise-2022.2-api.yaml.asc">PGP signature</a>, <a href="ref/gradle-enterprise-2022.2-api.yaml.asc.sha256">PGP signature SHA-256 checksum</a>)</p></td>
+        </tr>
+        <tr>
+         <td class="tableblock halign-left valign-top"><p class="tableblock">2022.1</p></td>
+         <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="ref/2022.1.html">Documentation</a></p></td>
+         <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="ref/gradle-enterprise-2022.1-api.yaml">Specification</a> (<a href="ref/gradle-enterprise-2022.1-api.yaml.sha256">SHA-256 checksum</a>, <a href="ref/gradle-enterprise-2022.1-api.yaml.asc">PGP signature</a>, <a href="ref/gradle-enterprise-2022.1-api.yaml.asc.sha256">PGP signature SHA-256 checksum</a>)</p></td>
+        </tr>
+       </tbody>
+      </table>
+     </div>
+    </div>
+   </div>
+   <div class="sect1">
+    <h2 id="about_the_export_api"><a class="anchor" href="#about_the_export_api"></a><a class="link" href="#about_the_export_api">Appendix A: About the Export API</a></h2>
+    <div class="sectionbody">
+     <div class="paragraph">
+      <p>The Gradle Enterprise API described in this document will eventually replace the <a href="/enterprise/export-api">Gradle Enterprise Export API</a>. At this time, the Gradle Enterprise API does not allow consuming the <a href="/enterprise/export-api/#individual_builds">raw events of a build as the Export API does</a>.</p>
+     </div>
+     <div class="paragraph">
+      <p>If your existing usage of the Export API can be replaced with the easier-to-use Gradle Enterprise API, please consider migrating. For assistance, please contact Gradle Enterprise support.</p>
+     </div>
+    </div>
+   </div>
+   <div class="sect1">
+    <h2 id="release_history"><a class="anchor" href="#release_history"></a><a class="link" href="#release_history">Appendix B: Release history</a></h2>
+    <div class="sectionbody">
+     <h3 id="2023_1_2" class="discrete">2023.1</h3>
+     <div class="ulist">
+      <div class="title">
+       12th April 2023
+      </div>
+      <ul>
+       <li> <p>Add new <code>cacheArtifactSize</code> to <code>/api/builds/{id}/gradle-build-cache-performance</code> and <code>/api/builds/{id}/maven-build-cache-performance</code> operation response</p> </li>
+       <li> <p>Add new <code>excludedTasks</code> to <code>/api/builds/{id}/gradle-attributes</code> operation response</p> </li>
+      </ul>
+     </div>
+     <h3 id="2022_4" class="discrete">2022.4</h3>
+     <div class="ulist">
+      <div class="title">
+       8th December 2022
+      </div>
+      <ul>
+       <li> <p>Add new <code>/api/test-distribution/*</code> endpoints for managing API keys and agent pools</p> </li>
+       <li> <p>Add new <code>/api/builds/{id}/gradle-projects</code> endpoint</p> </li>
+       <li> <p>Add new <code>/api/builds/{id}/maven-modules</code> endpoint</p> </li>
+       <li> <p>Introduce <code>fromInstant</code>, <code>fromBuild</code>, <code>reverse</code> query parameters on the <code>/api/builds</code> operation query</p> </li>
+       <li> <p>Deprecate <code>since</code> and <code>sinceBuild</code> query parameters on the <code>/api/builds</code> operation query</p> </li>
+      </ul>
+     </div>
+     <h3 id="2022_3" class="discrete">2022.3</h3>
+     <div class="ulist">
+      <div class="title">
+       10th August 2022
+      </div>
+      <ul>
+       <li> <p>Add <code>taskExecution.nonCacheabilityCategory</code> and <code>taskExecution.nonCacheabilityReason</code> to <code>/api/builds/{id}/gradle-build-cache-performance</code> operation response</p> </li>
+       <li> <p>Add <code>goalExecution.nonCacheabilityCategory</code> and <code>goalExecution.nonCacheabilityReason</code> to <code>/api/builds/{id}/maven-build-cache-performance</code> operation response</p> </li>
+       <li> <p>Add <code>taskExecution.taskType</code> to <code>/api/builds/{id}/gradle-build-cache-performance</code> operation response</p> </li>
+       <li> <p>Add <code>goalExecution.mojoType</code> to <code>/api/builds/{id}/maven-build-cache-performance</code> operation response</p> </li>
+       <li> <p>Add <code>buildCaches.remote.type</code> to <code>/api/builds/{id}/gradle-build-cache-performance</code> operation response</p> </li>
+       <li> <p>Add <code>buildCaches.remote.className</code> to <code>/api/builds/{id}/gradle-build-cache-performance</code> operation response</p> </li>
+       <li> <p>Add a <code>title</code> to <code>/api/builds</code> inlined query parameters schema</p> </li>
+      </ul>
+     </div>
+     <h3 id="2022_2" class="discrete">2022.2</h3>
+     <div class="ulist">
+      <div class="title">
+       19th April 2022
+      </div>
+      <ul>
+       <li> <p>Improve OpenAPI specification examples</p> </li>
+       <li> <p>Add <code>buildCaches.local.isPushEnabled</code> to <code>/api/builds/{id}/maven-build-cache-performance</code> operation response</p> </li>
+      </ul>
+     </div>
+     <h3 id="2022_1" class="discrete">2022.1</h3>
+     <div class="ulist">
+      <div class="title">
+       17th March 2022
+      </div>
+      <ul>
+       <li> <p>Initial release</p> </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+  </div>
+  <div id="footer">
+   <div id="footer-text">
+     Last updated 2023-04-18 06:10:09 +0200
+   </div>
+  </div>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/idea.min.css" integrity="sha384-ShrqMPQNj2A34EaFlusCRvrhdHlxQXt7coqOSn3HvOG06+b4kkuoGCCNa4HmE+LV" crossorigin="anonymous">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js" integrity="sha384-4l+9bhb7rakZ18megzl0/DWczL8ojbDl1jIEzBVffeMho9A6xB/lkqt1K0PC8Jin" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/languages/dockerfile.min.js" integrity="sha384-5TrkTRj8EM07q4oPGiK8VM6JA9PBrW9wqhx6LOFdeNikSVzS1EPWbUlWLWL+R/9h" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/languages/dns.min.js" integrity="sha384-+nrxzzUI2p35wH1nm/6DEpE1DCCYkKjfM6t2/2xh3qw0po6txqhd8s5stBmZBTJ9" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/languages/groovy.min.js" integrity="sha384-9dupACs+p9kaSey6BO0V2FzxQ2ildDxzimarMJOGZEUl+Wi7mZSwxD8eHeD9ZgZq" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/languages/java.min.js" integrity="sha384-ppS3kmYuIwUHk7ZpUIgfhshP0bdLTCuGZfTXAsF8MNaTCsTGSj7IKqFGm9ERyTMd" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/languages/json.min.js" integrity="sha384-iobZTYVzyrsWqW32ac+XJyMw7EWFbPi3u7zdOpEOVt/L0uR4Rfnt7UBD7cRYq19G" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/languages/kotlin.min.js" integrity="sha384-m7s7hvqy10rUilBF+4c5S7SNeBcBU9Nk8biWVpO2K3qIoBL10MH+kTCpUja8eNUa" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/languages/xml.min.js" integrity="sha384-QVZ+m2Q4pBQj3XpgpyE7kiKYY7Z/b55Xgf1hIpg/26PjfQtvn/YGYOt2B9F5eExw" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/languages/yaml.min.js" integrity="sha384-E9VpZq+poGRLEoyGHF52nKOUzQSPGQ6oRmNk96OLOhfQK7iQqFodh2oAlntRjKqN" crossorigin="anonymous"></script>
+  <script>setupHighlighting()</script>
+ </body>
+</html>

--- a/.github/scripts/update_api_spec_version.py
+++ b/.github/scripts/update_api_spec_version.py
@@ -1,35 +1,22 @@
 #!/usr/bin/env python3
 
 import requests
+import re
 import fileinput
 import sys
 from read_current_api_spec_version import get_current_api_spec_version
-from typing import Optional
 
-REFS_URL = "https://docs.gradle.com/enterprise/api-manual/ref"
-
-
-def get_possible_version_bumps(version: str) -> list[str]:
-    parts: list = version.split('.')
-    possible_bumps = []
-    for i in range(len(parts)):
-        bump = [int(p) for p in parts]
-        bump[i] += 1
-        if i < len(parts) - 1:
-            for j in range(i + 1, len(parts)):
-                bump[j] = 0
-        bump = ".".join([str(part) for part in bump])
-        possible_bumps.append(bump)
-    return possible_bumps
+VERSIONS_URL = "https://docs.gradle.com/enterprise/api-manual/"
+LATEST_VERSION_REGEX = r'<a [^>]*href="ref/gradle-enterprise-([\d.]+)-api\.yaml">Specification</a>'
 
 
-def get_first_available_version(versions: list[str]) -> Optional[str]:
-    for version in versions:
-        url = f"{REFS_URL}/gradle-enterprise-{version}-api.yaml"
-        status = requests.get(url).status_code
-        print(f"HTTP {status} (GET {url})", file=sys.stderr)
-        if status == 200:
-            return version
+def extract_latest_version():
+    resp = requests.get(VERSIONS_URL)
+    resp.raise_for_status()
+    match = re.search(LATEST_VERSION_REGEX, resp.text)
+    if not match:
+        raise RuntimeError("Failed to retrieve latest version")
+    return match.group(1)
 
 
 def update_version(properties_file, new_version):
@@ -43,14 +30,11 @@ def update_version(properties_file, new_version):
 
 def main(properties_file):
     current = get_current_api_spec_version(properties_file)
-    possible_bumps = get_possible_version_bumps(current)
-    print("Possible versions:", ', '.join(possible_bumps), file=sys.stderr)
-    available_update = get_first_available_version(possible_bumps)
-    if available_update:
-        print(f"Updating to {available_update}")
-        update_version(properties_file, available_update)
-    else:
-        print('No update available')
+    latest = extract_latest_version()
+    if current == latest:
+        exit(1)
+    update_version(properties_file, latest)
+    print(latest)
 
 
 if __name__ == '__main__':

--- a/.github/workflows/check-new-api-spec.yml
+++ b/.github/workflows/check-new-api-spec.yml
@@ -28,19 +28,19 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v3
       - name: 'Update API spec version'
-        run: ./.github/scripts/update_api_spec_version.py
-      - name: 'Read current spec version'
         run: |
-          version="$(./.github/scripts/read_current_api_spec_version.py)"
-          [[ -n "$version" ]]
-          echo "SPEC_VERSION=$version" | tee -a "$GITHUB_ENV"
+          if ./.github/scripts/update_api_spec_version.py | tee new.txt; then
+            echo "NEW_VERSION=$(cat new.txt)" >> $GITHUB_ENV
+          fi
+          rm new.txt || true
       - name: 'Create PR'
-        if: ${{ !inputs.dry_run }}
+        if: ${{ !inputs.dry_run && env.NEW_VERSION }}
         uses: peter-evans/create-pull-request@v5
         with:
-          branch: "feature/api-spec-${{ env.SPEC_VERSION }}"
-          commit-message: "Bump GE API spec version to ${{ env.SPEC_VERSION }}"
-          title: "Support Gradle Enterprise API ${{ env.SPEC_VERSION }}"
+          branch: "feature/api-spec-${{ env.NEW_VERSION }}"
+          commit-message: "Bump GE API spec version to ${{ env.NEW_VERSION }}"
+          title: "Bump GE API spec version to ${{ env.NEW_VERSION }}"
           body: "https://docs.gradle.com/enterprise/api-manual/#release_history"
           author: "github-actions <github-actions@github.com>"
           committer: "github-actions <github-actions@github.com>"
+          add-paths: "gradle.properties"


### PR DESCRIPTION
2023.1 spec was released, but workflow didn't detect it. Fix it by making it read the latest version right from the API website. It's simpler and more effective than the previous solution, which was blindly trying possible next version ref URLs.