### PR TITLE
Publish API interface test fixture

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     id("org.jetbrains.dokka") version "1.8.10"
     id("org.openapi.generator") version "6.5.0"
     `java-library`
+    `java-test-fixtures`
     `maven-publish`
 }
 

--- a/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/FakeGradleEnterpriseApi.kt
+++ b/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/FakeGradleEnterpriseApi.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 class FakeGradleEnterpriseApi(
     val builds: List<Build>,
-) : GradleEnterpriseApi {
+) : FakeGradleEnterpriseApiScaffold {
 
     val getBuildsCallCount = MutableStateFlow(0)
     val getGradleAtrributesCallCount = MutableStateFlow(0)
@@ -46,117 +46,5 @@ class FakeGradleEnterpriseApi(
         getGradleAtrributesCallCount.value++
         val attrs = readFromJsonResource<GradleAttributes>("gradle-attributes-response.json")
         return attrs.copy(id = id)
-    }
-
-    override suspend fun createOrUpdateBuildCacheNode(
-        name: String,
-        nodeConfiguration: NodeConfiguration,
-    ) {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun createOrUpdateTestDistributionAgentPool(
-        poolId: String,
-        testDistributionAgentPoolConfiguration: TestDistributionAgentPoolConfiguration,
-    ): TestDistributionAgentPoolConfigurationWithId {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun createTestDistributionAgentPool(testDistributionAgentPoolConfiguration: TestDistributionAgentPoolConfiguration): TestDistributionAgentPoolConfigurationWithId {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun deleteTestDistributionAgentPool(poolId: String) {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun generateTestDistributionApiKey(): TestDistributionApiKey {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getBuild(id: String, availabilityWaitTimeoutSecs: Int?): Build {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getBuildCacheNode(name: String): NodeConfiguration {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getGradleBuildCachePerformance(
-        id: String,
-        availabilityWaitTimeoutSecs: Int?,
-    ): GradleBuildCachePerformance {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getGradleProjects(
-        id: String,
-        availabilityWaitTimeoutSecs: Int?,
-    ): List<GradleProject> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getMavenAttributes(
-        id: String,
-        availabilityWaitTimeoutSecs: Int?,
-    ): MavenAttributes {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getMavenBuildCachePerformance(
-        id: String,
-        availabilityWaitTimeoutSecs: Int?,
-    ): MavenBuildCachePerformance {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getMavenModules(
-        id: String,
-        availabilityWaitTimeoutSecs: Int?,
-    ): List<MavenModule> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getTestDistributionAgentPool(poolId: String): TestDistributionAgentPoolConfigurationWithId {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getTestDistributionAgentPoolStatus(poolId: String): TestDistributionAgentPoolStatus {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getTestDistributionApiKey(keyPrefix: String): TestDistributionApiKeyPrefix {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getVersion(): GradleEnterpriseVersion {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun initiatePurgeOfBuildCacheNode(name: String) {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun insertTestDistributionApiKey(
-        keyPrefix: String,
-        testDistributionApiKey: TestDistributionApiKey,
-    ): TestDistributionApiKeyPrefix {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun listTestDistributionAgentPools(): TestDistributionAgentPoolPage {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun listTestDistributionApiKeys(): TestDistributionApiKeyPrefixPage {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun regenerateSecretOfBuildCacheNode(name: String): KeySecretPair {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun revokeTestDistributionApiKey(keyPrefix: String) {
-        TODO("Not yet implemented")
     }
 }

--- a/src/testFixtures/kotlin/com/gabrielfeo/gradle/enterprise/api/FakeGradleEnterpriseApiScaffold.kt
+++ b/src/testFixtures/kotlin/com/gabrielfeo/gradle/enterprise/api/FakeGradleEnterpriseApiScaffold.kt
@@ -1,0 +1,149 @@
+package com.gabrielfeo.gradle.enterprise.api
+
+import com.gabrielfeo.gradle.enterprise.api.model.*
+
+/**
+ * Scaffold for a fake `GradleEnterpriseApi` implementation with default methods throwing a
+ * [NotImplementedError]. Extend this interface and override methods to fake behavior as needed.
+ */
+interface FakeGradleEnterpriseApiScaffold : GradleEnterpriseApi {
+
+    override suspend fun createOrUpdateBuildCacheNode(
+        name: String,
+        nodeConfiguration: NodeConfiguration,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun createOrUpdateTestDistributionAgentPool(
+        poolId: String,
+        testDistributionAgentPoolConfiguration: TestDistributionAgentPoolConfiguration,
+    ): TestDistributionAgentPoolConfigurationWithId {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun createTestDistributionAgentPool(
+        testDistributionAgentPoolConfiguration: TestDistributionAgentPoolConfiguration,
+    ): TestDistributionAgentPoolConfigurationWithId {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun deleteTestDistributionAgentPool(poolId: String) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun generateTestDistributionApiKey(): TestDistributionApiKey {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getBuild(id: String, availabilityWaitTimeoutSecs: Int?): Build {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getBuildCacheNode(name: String): NodeConfiguration {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getBuilds(
+        since: Long?,
+        sinceBuild: String?,
+        fromInstant: Long?,
+        fromBuild: String?,
+        reverse: Boolean?,
+        maxBuilds: Int?,
+        maxWaitSecs: Int?,
+    ): List<Build> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getGradleAttributes(
+        id: String,
+        availabilityWaitTimeoutSecs: Int?,
+    ): GradleAttributes {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getGradleBuildCachePerformance(
+        id: String,
+        availabilityWaitTimeoutSecs: Int?,
+    ): GradleBuildCachePerformance {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getGradleProjects(
+        id: String,
+        availabilityWaitTimeoutSecs: Int?,
+    ): List<GradleProject> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getMavenAttributes(
+        id: String,
+        availabilityWaitTimeoutSecs: Int?,
+    ): MavenAttributes {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getMavenBuildCachePerformance(
+        id: String,
+        availabilityWaitTimeoutSecs: Int?,
+    ): MavenBuildCachePerformance {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getMavenModules(
+        id: String,
+        availabilityWaitTimeoutSecs: Int?,
+    ): List<MavenModule> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getTestDistributionAgentPool(
+        poolId: String,
+    ): TestDistributionAgentPoolConfigurationWithId {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getTestDistributionAgentPoolStatus(
+        poolId: String,
+    ): TestDistributionAgentPoolStatus {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getTestDistributionApiKey(
+        keyPrefix: String,
+    ): TestDistributionApiKeyPrefix {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getVersion(): GradleEnterpriseVersion {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun initiatePurgeOfBuildCacheNode(name: String) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun insertTestDistributionApiKey(
+        keyPrefix: String,
+        testDistributionApiKey: TestDistributionApiKey,
+    ): TestDistributionApiKeyPrefix {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun listTestDistributionAgentPools(): TestDistributionAgentPoolPage {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun listTestDistributionApiKeys(): TestDistributionApiKeyPrefixPage {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun regenerateSecretOfBuildCacheNode(name: String): KeySecretPair {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun revokeTestDistributionApiKey(keyPrefix: String) {
+        TODO("Not yet implemented")
+    }
+}


### PR DESCRIPTION
Clients that test logic relying on library interfaces will create a fake implementation. Since the library itself does this, start publishing test fixtures with such code.