### PR TITLE
Fix token reading in Linux

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 import java.net.URL
 import org.jetbrains.dokka.DokkaConfiguration.Visibility.PUBLIC
 import org.jetbrains.dokka.gradle.DokkaTask
@@ -177,8 +179,23 @@ publishing {
 }
 
 testing {
-    suites.withType<JvmTestSuite> {
-        useKotlinTest()
+    suites {
+        getByName<JvmTestSuite>("test") {
+            dependencies {
+                implementation("com.squareup.okhttp3:mockwebserver:4.11.0")
+                implementation("com.squareup.okio:okio:3.3.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.0")
+            }
+        }
+        register<JvmTestSuite>("integrationTest") {
+            dependencies {
+                implementation(project())
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.0")
+            }
+        }
+        withType<JvmTestSuite> {
+            useKotlinTest()
+        }
     }
 }
 
@@ -200,7 +217,4 @@ dependencies {
     implementation("com.squareup.retrofit2:converter-moshi:2.9.0")
     implementation("com.squareup.retrofit2:converter-scalars:2.9.0")
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.0")
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.11.0")
-    testImplementation("com.squareup.okio:okio:3.3.0")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.0")
 }

--- a/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/GradleEnterpriseIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/GradleEnterpriseIntegrationTest.kt
@@ -1,0 +1,17 @@
+package com.gabrielfeo.gradle.enterprise.api.internal
+
+import com.gabrielfeo.gradle.enterprise.api.gradleEnterpriseApi
+import com.gabrielfeo.gradle.enterprise.api.shutdown
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GradleEnterpriseIntegrationTest {
+
+    @Test
+    fun canFetchBuilds() = runTest {
+        val builds = gradleEnterpriseApi.getBuilds(since = 0, maxBuilds = 1)
+        assertEquals(1, builds.size)
+        shutdown()
+    }
+}

--- a/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/KeychainIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/KeychainIntegrationTest.kt
@@ -1,0 +1,17 @@
+package com.gabrielfeo.gradle.enterprise.api.internal
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+class KeychainIntegrationTest {
+
+    val keychain = RealKeychain(RealSystemProperties)
+
+    @Test
+    fun getApiToken() {
+        assertFalse(
+            keychain["gradle-enterprise-api-token"].isNullOrEmpty(),
+            "Keychain returned null or empty",
+        )
+    }
+}

--- a/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/Keychain.kt
+++ b/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/Keychain.kt
@@ -9,10 +9,13 @@ interface Keychain {
 }
 
 class RealKeychain(
-    private val env: Env,
+    private val systemProperties: SystemProperties,
 ) : Keychain {
     override fun get(entry: String): String? {
-        val login = env["LOGNAME"]
+        val login = systemProperties["user.name"] ?: let {
+            Logger.getGlobal().log(Level.INFO, "Failed to get key from keychain (null user.name)")
+            return null
+        }
         val process = ProcessBuilder(
             "security", "find-generic-password", "-w", "-a", login, "-s", entry
         ).start()

--- a/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/SystemProperties.kt
+++ b/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/SystemProperties.kt
@@ -1,0 +1,9 @@
+package com.gabrielfeo.gradle.enterprise.api.internal
+
+interface SystemProperties {
+    operator fun get(name: String): String?
+}
+
+object RealSystemProperties : SystemProperties {
+    override fun get(name: String): String? = System.getProperty(name)
+}

--- a/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/OkHttpClientTest.kt
+++ b/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/OkHttpClientTest.kt
@@ -2,6 +2,7 @@ package com.gabrielfeo.gradle.enterprise.api
 
 import com.gabrielfeo.gradle.enterprise.api.internal.FakeEnv
 import com.gabrielfeo.gradle.enterprise.api.internal.FakeKeychain
+import com.gabrielfeo.gradle.enterprise.api.internal.FakeSystemProperties
 import com.gabrielfeo.gradle.enterprise.api.internal.auth.HttpBearerAuth
 import com.gabrielfeo.gradle.enterprise.api.internal.buildOkHttpClient
 import com.gabrielfeo.gradle.enterprise.api.internal.caching.CacheEnforcingInterceptor
@@ -90,7 +91,7 @@ class OkHttpClientTest {
             env["GRADLE_ENTERPRISE_API_TOKEN"] = "example-token"
         if ("GRADLE_ENTERPRISE_API_URL" !in env)
             env["GRADLE_ENTERPRISE_API_URL"] = "example-url"
-        val options = Options(env, FakeKeychain()).apply {
+        val options = Options(env, FakeSystemProperties.macOs, FakeKeychain()).apply {
             clientBuilder?.let {
                 httpClient.clientBuilder = { it }
             }

--- a/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/RetrofitTest.kt
+++ b/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/RetrofitTest.kt
@@ -1,10 +1,7 @@
 package com.gabrielfeo.gradle.enterprise.api
 
-import com.gabrielfeo.gradle.enterprise.api.internal.FakeEnv
-import com.gabrielfeo.gradle.enterprise.api.internal.FakeKeychain
+import com.gabrielfeo.gradle.enterprise.api.internal.*
 import com.gabrielfeo.gradle.enterprise.api.internal.auth.HttpBearerAuth
-import com.gabrielfeo.gradle.enterprise.api.internal.buildOkHttpClient
-import com.gabrielfeo.gradle.enterprise.api.internal.buildRetrofit
 import com.gabrielfeo.gradle.enterprise.api.internal.caching.CacheEnforcingInterceptor
 import com.gabrielfeo.gradle.enterprise.api.internal.caching.CacheHitLoggingInterceptor
 import com.squareup.moshi.Moshi
@@ -38,7 +35,7 @@ class RetrofitTest {
         val env = FakeEnv(*envVars)
         if ("GRADLE_ENTERPRISE_API_TOKEN" !in env)
             env["GRADLE_ENTERPRISE_API_TOKEN"] = "example-token"
-        val options = Options(env, FakeKeychain())
+        val options = Options(env, FakeSystemProperties.macOs, FakeKeychain())
         return buildRetrofit(
             options = options,
             client = buildOkHttpClient(options),

--- a/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/FakeSystemProperties.kt
+++ b/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/FakeSystemProperties.kt
@@ -1,0 +1,18 @@
+package com.gabrielfeo.gradle.enterprise.api.internal
+
+class FakeSystemProperties(
+    vararg vars: Pair<String, String?>,
+) : SystemProperties {
+
+    companion object {
+        val macOs = FakeSystemProperties("os.name" to "Mac OS X")
+        val linux = FakeSystemProperties("os.name" to "Linux")
+    }
+
+    private val vars = vars.toMap(HashMap())
+
+    override fun get(name: String) = vars[name]
+
+    operator fun set(name: String, value: String?) = vars.put(name, value)
+    operator fun contains(name: String) = name in vars
+}


### PR DESCRIPTION
Closes #54 

### #54

Trying to use it in Linux with `GRADLE_ENTERPRISE_API_TOKEN` fails first due to having no `LOGNAME` variable:

```
null
java.lang.NullPointerException
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1090)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1071)
	at com.gabrielfeo.gradle.enterprise.api.internal.RealKeychain.get(Keychain.kt:18)
	at com.gabrielfeo.gradle.enterprise.api.Options$GradleEnterpriseInstanceOptions$token$1.invoke(Options.kt:56)
	at com.gabrielfeo.gradle.enterprise.api.Options$GradleEnterpriseInstanceOptions$token$1.invoke(Options.kt:55)
	at com.gabrielfeo.gradle.enterprise.api.internal.OkHttpClientKt.addNetworkInterceptors(OkHttpClient.kt:49)
	at com.gabrielfeo.gradle.enterprise.api.internal.OkHttpClientKt.buildOkHttpClient(OkHttpClient.kt:27)
	at com.gabrielfeo.gradle.enterprise.api.internal.OkHttpClientKt$okHttpClient$2.invoke(OkHttpClient.kt:16)
	at com.gabrielfeo.gradle.enterprise.api.internal.OkHttpClientKt$okHttpClient$2.invoke(OkHttpClient.kt:15)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at com.gabrielfeo.gradle.enterprise.api.internal.OkHttpClientKt.getOkHttpClient(OkHttpClient.kt:15)
	at com.gabrielfeo.gradle.enterprise.api.internal.RetrofitKt$retrofit$2.invoke(Retrofit.kt:15)
	at com.gabrielfeo.gradle.enterprise.api.internal.RetrofitKt$retrofit$2.invoke(Retrofit.kt:12)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at com.gabrielfeo.gradle.enterprise.api.internal.RetrofitKt.getRetrofit(Retrofit.kt:12)
	at com.gabrielfeo.gradle.enterprise.api.ApiKt$gradleEnterpriseApi$2.invoke(Api.kt:11)
	at com.gabrielfeo.gradle.enterprise.api.ApiKt$gradleEnterpriseApi$2.invoke(Api.kt:10)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at com.gabrielfeo.gradle.enterprise.api.ApiKt.getGradleEnterpriseApi(Api.kt:10)
```

After setting a dummy `LOGNAME`, it'll still fail because ProcessBuilder throws an `IOException` for command not found, instead of just setting status to 127:

```
Cannot run program "security": error=2, No such file or directory
java.io.IOException: Cannot run program "security": error=2, No such file or directory
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1128)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1071)
	at com.gabrielfeo.gradle.enterprise.api.internal.RealKeychain.get(Keychain.kt:18)
	at com.gabrielfeo.gradle.enterprise.api.Options$GradleEnterpriseInstanceOptions$token$1.invoke(Options.kt:56)
	at com.gabrielfeo.gradle.enterprise.api.Options$GradleEnterpriseInstanceOptions$token$1.invoke(Options.kt:55)
	at com.gabrielfeo.gradle.enterprise.api.internal.OkHttpClientKt.addNetworkInterceptors(OkHttpClient.kt:49)
	at com.gabrielfeo.gradle.enterprise.api.internal.OkHttpClientKt.buildOkHttpClient(OkHttpClient.kt:27)
	at com.gabrielfeo.gradle.enterprise.api.internal.OkHttpClientKt$okHttpClient$2.invoke(OkHttpClient.kt:16)
	at com.gabrielfeo.gradle.enterprise.api.internal.OkHttpClientKt$okHttpClient$2.invoke(OkHttpClient.kt:15)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at com.gabrielfeo.gradle.enterprise.api.internal.OkHttpClientKt.getOkHttpClient(OkHttpClient.kt:15)
	at com.gabrielfeo.gradle.enterprise.api.internal.RetrofitKt$retrofit$2.invoke(Retrofit.kt:15)
	at com.gabrielfeo.gradle.enterprise.api.internal.RetrofitKt$retrofit$2.invoke(Retrofit.kt:12)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at com.gabrielfeo.gradle.enterprise.api.internal.RetrofitKt.getRetrofit(Retrofit.kt:12)
	at com.gabrielfeo.gradle.enterprise.api.ApiKt$gradleEnterpriseApi$2.invoke(Api.kt:11)
	at com.gabrielfeo.gradle.enterprise.api.ApiKt$gradleEnterpriseApi$2.invoke(Api.kt:10)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at com.gabrielfeo.gradle.enterprise.api.ApiKt.getGradleEnterpriseApi(Api.kt:10)
```