### PR TITLE
Disable test fixtures publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,6 +143,11 @@ java {
     }
 }
 
+components.getByName<AdhocComponentWithVariants>("java").apply {
+    withVariantsFromConfiguration(configurations["testFixturesApiElements"]) { skip() }
+    withVariantsFromConfiguration(configurations["testFixturesRuntimeElements"]) { skip() }
+}
+
 tasks.withType<DokkaTask>().configureEach {
     dokkaSourceSets.all {
         sourceLink {


### PR DESCRIPTION
While #53 isn't addressed.

---

### #53 

Currently, the library is "deployed" to JitPack. Maven Central was already a desire, but JitPack is actually breaking test fixtures variant in the library's Gradle Module Metadata. As a result, no one can consume the fixtures artifact.

https://jitpack.io/com/github/gabrielfeo/gradle-enterprise-api-kotlin/0.16.0-beta/gradle-enterprise-api-kotlin-0.16.0-beta.module
https://gradle-community.slack.com/archives/CAHSN3LDN/p1683828623398169