### PR TITLE
Use a stable path for default HTTP cache dir

### DIFF
--- a/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/Config.kt
+++ b/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/Config.kt
@@ -134,7 +134,7 @@ data class Config(
          */
         val cacheDir: File =
             env["GRADLE_ENTERPRISE_API_CACHE_DIR"]?.let(::File)
-                ?: File(System.getProperty("java.io.tmpdir"), "gradle-enterprise-api-kotlin-cache"),
+                ?: File(systemProperties["user.home"], ".gradle-enterprise-api-kotlin-cache"),
 
         /**
          * Max size of the HTTP cache. By default, uses environment variable


### PR DESCRIPTION
Use the home directory as it's unpredictable when `tmpdir` contents are cleared. Makes it easier to identify when the cache max size is being hit, or a path isn't being properly cached.