### PR TITLE
Don't fail eagerly from missing token

### DIFF
--- a/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/GradleEnterpriseApi.kt
+++ b/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/GradleEnterpriseApi.kt
@@ -64,7 +64,7 @@ interface GradleEnterpriseApi {
 
 }
 
-private class RealGradleEnterpriseApi(
+internal class RealGradleEnterpriseApi(
     override val config: Config = Config(),
 ) : GradleEnterpriseApi {
 
@@ -80,10 +80,10 @@ private class RealGradleEnterpriseApi(
         )
     }
 
-    override val buildsApi: BuildsApi by lazy(retrofit::create)
-    override val buildCacheApi: BuildCacheApi by lazy(retrofit::create)
-    override val metaApi: MetaApi by lazy(retrofit::create)
-    override val testDistributionApi: TestDistributionApi by lazy(retrofit::create)
+    override val buildsApi: BuildsApi by lazy { retrofit.create() }
+    override val buildCacheApi: BuildCacheApi by lazy { retrofit.create() }
+    override val metaApi: MetaApi by lazy { retrofit.create() }
+    override val testDistributionApi: TestDistributionApi by lazy { retrofit.create() }
 
     override fun shutdown() {
         okHttpClient.run {

--- a/library/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/GradleEnterpriseApiTest.kt
+++ b/library/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/GradleEnterpriseApiTest.kt
@@ -1,0 +1,39 @@
+package com.gabrielfeo.gradle.enterprise.api
+
+import com.gabrielfeo.gradle.enterprise.api.internal.*
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
+import kotlin.test.assertContains
+
+class GradleEnterpriseApiTest {
+
+    @Test
+    fun `Fails eagerly if no API URL`() {
+        env = FakeEnv()
+        keychain = FakeKeychain()
+        systemProperties = FakeSystemProperties.linux
+        val error = assertThrows<Exception> {
+            GradleEnterpriseApi.newInstance(Config())
+        }
+        error.assertRootMessageContains("GRADLE_ENTERPRISE_API_URL")
+    }
+
+    @Test
+    fun `Fails lazily if no API token`() {
+        env = FakeEnv("GRADLE_ENTERPRISE_API_URL" to "example-url")
+        keychain = FakeKeychain()
+        systemProperties = FakeSystemProperties.linux
+        val api = assertDoesNotThrow {
+            GradleEnterpriseApi.newInstance(Config())
+        }
+        val error = assertThrows<Exception> {
+            api.buildsApi.toString()
+        }
+        error.assertRootMessageContains("GRADLE_ENTERPRISE_API_TOKEN")
+    }
+
+    private fun Throwable.assertRootMessageContains(text: String) {
+        cause?.assertRootMessageContains(text) ?: assertContains(message.orEmpty(), text)
+    }
+}


### PR DESCRIPTION
Using a method reference of `retrofit` for the lazy delegates of properties causes `retrofit` to be eagerly initialized.