### PR TITLE
Set up publishing to Maven Central

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -10,6 +10,10 @@ inputs:
   path-to-upload:
     description: "Path to upload as artifact"
     required: false
+  dry-run:
+    description: "Whether to --dry-run"
+    type: boolean
+    default: false
 runs:
   using: "composite"
   steps:
@@ -20,12 +24,18 @@ runs:
         java-version: 8
     - name: Validate Gradle wrapper JAR
       uses: gradle/wrapper-validation-action@v1.0.6
-    - name: Run Gradle
+    - name: Set up Gradle
       uses: gradle/gradle-build-action@v2.1.4
-      with:
-        arguments: ${{ inputs.args }}
+    - name: Run Gradle
+      shell: bash
+      run: |
+        if [[ "${{ inputs.dry-run }}" == "true" ]]; then
+          gradle --dry-run ${{ inputs.args }}
+        else
+          gradle ${{ inputs.args }}
+        fi
     - name: Upload
-      if: ${{ inputs.path-to-upload }}
+      if: ${{ inputs.path-to-upload && !inputs.dry-run }}
       uses: actions/upload-artifact@v3.0.0
       with:
         name: ${{ inputs.artifact-name }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -79,6 +79,11 @@ jobs:
     with:
       dry_run: true
 
+  dry-run-publish-library:
+    uses: ./.github/workflows/publish-library.yml
+    with:
+      dry_run: true
+
   dry-run-update-api-spec:
     uses: ./.github/workflows/update-api-spec.yml
     with:

--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -1,0 +1,47 @@
+name: 'Publish library to Central'
+
+on:
+  push:
+    tags: ['*']
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run'
+        type: boolean
+        required: false
+  workflow_call:
+    inputs:
+      dry_run:
+        description: 'Dry run'
+        type: boolean
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: gradle publishLibraryPublicationToMavenCentralRepository
+        uses: ./.github/actions/build
+        with:
+          dry-run: ${{ inputs.dry_run }}
+          args: >-
+            publishLibraryPublicationToMavenCentralRepository
+            --rerun-tasks
+            '-Pversion=${{ github.ref_name }}'
+            '-Pmaven.central.username=${{ secrets.MAVEN_CENTRAL_USERNAME }}'
+            '-Pmaven.central.password=${{ secrets.MAVEN_CENTRAL_PASSWORD }}'
+            '-Psigning.password=${{ secrets.GPG_PASSWORD }}'
+            '-Psigning.secretKey=${{ secrets.GPG_SECRET_KEY }}'
+          artifact-name: 'outputs'
+          path-to-upload: |
+            library/build/*-api.yaml
+            library/build/generated/open-api-generator/**/*
+            library/build/publications/**/*
+            library/build/libs/**/*

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@ org.gradle.caching=true
 version=SNAPSHOT
 # Must be later than 2022.1
 gradle.enterprise.version=2022.4
-group=com.github.gabrielfeo
+group=com.gabrielfeo
 artifact=gradle-enterprise-api-kotlin


### PR DESCRIPTION
Closes #53 and implements proper signing.

---

#53

Currently, the library is "deployed" to JitPack. Maven Central was already a desire, but JitPack is actually breaking test fixtures variant in the library's Gradle Module Metadata. As a result, no one can consume the fixtures artifact.

- https://jitpack.io/com/github/gabrielfeo/gradle-enterprise-api-kotlin/0.16.0-beta/gradle-enterprise-api-kotlin-0.16.0-beta.module
- https://gradle-community.slack.com/archives/CAHSN3LDN/p1683828623398169