### PR TITLE
Ensure built with same JDK on local and CI

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -20,8 +20,8 @@ runs:
     - name: Set up Java
       uses: actions/setup-java@v2
       with:
-        distribution: temurin
-        java-version: 8
+        distribution: zulu
+        java-version: 20
     - name: Validate Gradle wrapper JAR
       uses: gradle/wrapper-validation-action@v1.0.6
     - name: Set up Gradle

--- a/examples/example-project/app/build.gradle.kts
+++ b/examples/example-project/app/build.gradle.kts
@@ -12,6 +12,12 @@ repositories {
     maven(url = "https://jitpack.io")
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
+}
+
 dependencies {
     implementation("com.github.gabrielfeo:gradle-enterprise-api-kotlin:0.16.0")
 }

--- a/examples/example-project/settings.gradle.kts
+++ b/examples/example-project/settings.gradle.kts
@@ -1,9 +1,13 @@
 rootProject.name = "example-project"
 
-include(":app")
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
 
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
     }
 }
+
+include(":app")

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -139,6 +139,7 @@ java {
     withJavadocJar()
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(8))
+        vendor.set(JvmVendorSpec.AZUL)
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.gradle.enterprise") version("3.13.2")
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
 }
 
 include(


### PR DESCRIPTION
Configure toolchain auto-provisioning so that CI uses Azul 8 for compiling. M1 Macs must use Azul because it's the only native JDK 8 for ARM.