### PR TITLE
Fix publish javadoc

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -35,9 +35,9 @@ runs:
           gradle ${{ inputs.args }}
         fi
     - name: Upload
-      if: ${{ inputs.path-to-upload && inputs.dry-run != true }}
+      if: ${{ inputs.path-to-upload }}
       uses: actions/upload-artifact@v3.0.0
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.path-to-upload }}
-        if-no-files-found: error
+        if-no-files-found: warn

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -35,7 +35,7 @@ runs:
           gradle ${{ inputs.args }}
         fi
     - name: Upload
-      if: ${{ inputs.path-to-upload && !inputs.dry-run }}
+      if: ${{ inputs.path-to-upload && inputs.dry-run != true }}
       uses: actions/upload-artifact@v3.0.0
       with:
         name: ${{ inputs.artifact-name }}

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -8,13 +8,13 @@ on:
       dry_run:
         description: 'Dry run'
         type: boolean
-        required: false
+        default: false
   workflow_call:
     inputs:
       dry_run:
         description: 'Dry run'
         type: boolean
-        required: true
+        default: false
 
 defaults:
   run:

--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -8,13 +8,13 @@ on:
       dry_run:
         description: 'Dry run'
         type: boolean
-        required: false
+        default: false
   workflow_call:
     inputs:
       dry_run:
         description: 'Dry run'
         type: boolean
-        required: true
+        default: false
 
 defaults:
   run:

--- a/.github/workflows/update-api-spec.yml
+++ b/.github/workflows/update-api-spec.yml
@@ -8,13 +8,13 @@ on:
       dry_run:
         description: 'Dry run'
         type: boolean
-        required: false
+        default: false
   workflow_call:
     inputs:
       dry_run:
         description: 'Dry run'
         type: boolean
-        required: true
+        default: false
 
 defaults:
   run:
@@ -34,7 +34,7 @@ jobs:
           fi
           rm new.txt || true
       - name: 'Create PR'
-        if: ${{ !inputs.dry_run && env.NEW_VERSION }}
+        if: ${{ inputs.dry_run != true && env.NEW_VERSION }}
         uses: peter-evans/create-pull-request@v5
         with:
           branch: "feature/api-spec-${{ env.NEW_VERSION }}"


### PR DESCRIPTION
By having a default value for `dry-run` in the build action and checking for mere presence as `!inputs.dry-run`, the default was effectively true. As a result, [the latest javadoc publishing failed][1].

Change all conditions to check for `true` and let `build-javadoc` upload artifacts even when dry-run, as it only matters that `publish-javadoc` not push them the branch afterwards.

[1]: https://github.com/gabrielfeo/gradle-enterprise-api-kotlin/actions/runs/5081949753/jobs/9131025423