### PR TITLE
Fix configuration via code

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -177,6 +177,7 @@ tasks.named<Jar>("javadocJar") {
 testing {
     suites {
         getByName<JvmTestSuite>("test") {
+            useKotlinTest()
             dependencies {
                 implementation("com.squareup.okhttp3:mockwebserver:4.11.0")
                 implementation("com.squareup.okio:okio:3.3.0")
@@ -184,12 +185,10 @@ testing {
             }
         }
         register<JvmTestSuite>("integrationTest") {
+            useJUnitJupiter()
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.1")
             }
-        }
-        withType<JvmTestSuite> {
-            useKotlinTest()
         }
     }
 }
@@ -198,7 +197,13 @@ kotlin {
     target {
         val main by compilations.getting
         val integrationTest by compilations.getting
+        val test by compilations.getting
+        val testFixtures by compilations.getting
+        test.associateWith(main)
+        test.associateWith(testFixtures)
         integrationTest.associateWith(main)
+        integrationTest.associateWith(testFixtures)
+        testFixtures.associateWith(main)
     }
 }
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -177,7 +177,6 @@ tasks.named<Jar>("javadocJar") {
 testing {
     suites {
         getByName<JvmTestSuite>("test") {
-            useKotlinTest()
             dependencies {
                 implementation("com.squareup.okhttp3:mockwebserver:4.11.0")
                 implementation("com.squareup.okio:okio:3.3.0")
@@ -185,10 +184,12 @@ testing {
             }
         }
         register<JvmTestSuite>("integrationTest") {
-            useJUnitJupiter()
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.1")
             }
+        }
+        withType<JvmTestSuite>().configureEach {
+            useKotlinTest()
         }
     }
 }

--- a/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/GradleEnterpriseApiIntegrationTest.kt
+++ b/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/GradleEnterpriseApiIntegrationTest.kt
@@ -3,9 +3,9 @@ package com.gabrielfeo.gradle.enterprise.api.internal
 import com.gabrielfeo.gradle.enterprise.api.Config
 import com.gabrielfeo.gradle.enterprise.api.GradleEnterpriseApi
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import kotlin.test.assertEquals
+import kotlin.test.Test
 
 class GradleEnterpriseApiIntegrationTest {
 

--- a/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/GradleEnterpriseApiIntegrationTest.kt
+++ b/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/GradleEnterpriseApiIntegrationTest.kt
@@ -1,9 +1,11 @@
 package com.gabrielfeo.gradle.enterprise.api.internal
 
+import com.gabrielfeo.gradle.enterprise.api.Config
 import com.gabrielfeo.gradle.enterprise.api.GradleEnterpriseApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 
 class GradleEnterpriseApiIntegrationTest {
 
@@ -14,10 +16,16 @@ class GradleEnterpriseApiIntegrationTest {
         GradleEnterpriseApi.shutdown()
     }
 
-//    @Test
-//    fun canBuildNewInstanceWithCodeConfiguration() = runTest {
-//        val builds = GradleEnterpriseApi.buildsApi.getBuilds(since = 0, maxBuilds = 1)
-//        assertEquals(1, builds.size)
-//        GradleEnterpriseApi.shutdown()
-//    }
+    @Test
+    fun canBuildNewInstanceWithCodeConfiguration() = runTest {
+        env = FakeEnv()
+        keychain = FakeKeychain()
+        assertDoesNotThrow {
+            val config = Config(
+                apiUrl = "https://google.com/api/",
+                apiToken = { "" }
+            )
+            GradleEnterpriseApi.newInstance(config)
+        }
+    }
 }

--- a/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/GradleEnterpriseApiIntegrationTest.kt
+++ b/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/GradleEnterpriseApiIntegrationTest.kt
@@ -2,15 +2,22 @@ package com.gabrielfeo.gradle.enterprise.api.internal
 
 import com.gabrielfeo.gradle.enterprise.api.GradleEnterpriseApi
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class GradleEnterpriseApiIntegrationTest {
 
     @Test
-    fun canFetchBuilds() = runTest {
+    fun canFetchBuildsWithDefaultInstance() = runTest {
         val builds = GradleEnterpriseApi.buildsApi.getBuilds(since = 0, maxBuilds = 1)
         assertEquals(1, builds.size)
         GradleEnterpriseApi.shutdown()
     }
+
+//    @Test
+//    fun canBuildNewInstanceWithCodeConfiguration() = runTest {
+//        val builds = GradleEnterpriseApi.buildsApi.getBuilds(since = 0, maxBuilds = 1)
+//        assertEquals(1, builds.size)
+//        GradleEnterpriseApi.shutdown()
+//    }
 }

--- a/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/GradleEnterpriseApiIntegrationTest.kt
+++ b/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/GradleEnterpriseApiIntegrationTest.kt
@@ -11,19 +11,21 @@ class GradleEnterpriseApiIntegrationTest {
 
     @Test
     fun canFetchBuildsWithDefaultInstance() = runTest {
+        env = RealEnv
+        keychain = RealKeychain(RealSystemProperties)
         val builds = GradleEnterpriseApi.buildsApi.getBuilds(since = 0, maxBuilds = 1)
         assertEquals(1, builds.size)
         GradleEnterpriseApi.shutdown()
     }
 
     @Test
-    fun canBuildNewInstanceWithCodeConfiguration() = runTest {
+    fun canBuildNewInstanceWithPureCodeConfiguration() = runTest {
         env = FakeEnv()
         keychain = FakeKeychain()
         assertDoesNotThrow {
             val config = Config(
                 apiUrl = "https://google.com/api/",
-                apiToken = { "" }
+                apiToken = { "" },
             )
             GradleEnterpriseApi.newInstance(config)
         }

--- a/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/KeychainIntegrationTest.kt
+++ b/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/KeychainIntegrationTest.kt
@@ -8,6 +8,8 @@ internal class KeychainIntegrationTest {
 
     @Test
     fun getApiToken() {
+        env = RealEnv
+        keychain = RealKeychain(RealSystemProperties)
         val result = keychain.get("gradle-enterprise-api-token")
         assertInstanceOf(KeychainResult.Success::class.java, result)
         val success = result as KeychainResult.Success

--- a/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/KeychainIntegrationTest.kt
+++ b/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/KeychainIntegrationTest.kt
@@ -1,8 +1,7 @@
 package com.gabrielfeo.gradle.enterprise.api.internal
 
 import com.gabrielfeo.gradle.enterprise.api.internal.keychain
-import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.Test
+import kotlin.test.*
 
 internal class KeychainIntegrationTest {
 
@@ -11,8 +10,7 @@ internal class KeychainIntegrationTest {
         env = RealEnv
         keychain = RealKeychain(RealSystemProperties)
         val result = keychain.get("gradle-enterprise-api-token")
-        assertInstanceOf(KeychainResult.Success::class.java, result)
-        val success = result as KeychainResult.Success
-        assertFalse(success.token.isNullOrBlank(), "Keychain returned null or blank")
+        assertIs<KeychainResult.Success>(result)
+        assertFalse(result.token.isNullOrBlank(), "Keychain returned null or blank")
     }
 }

--- a/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/KeychainIntegrationTest.kt
+++ b/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/KeychainIntegrationTest.kt
@@ -1,16 +1,16 @@
 package com.gabrielfeo.gradle.enterprise.api.internal
 
 import com.gabrielfeo.gradle.enterprise.api.internal.keychain
-import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertIs
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 
 internal class KeychainIntegrationTest {
 
     @Test
     fun getApiToken() {
         val result = keychain.get("gradle-enterprise-api-token")
-        assertIs<KeychainResult.Success>(result)
-        assertFalse(result.token.isNullOrBlank(), "Keychain returned null or blank")
+        assertInstanceOf(KeychainResult.Success::class.java, result)
+        val success = result as KeychainResult.Success
+        assertFalse(success.token.isNullOrBlank(), "Keychain returned null or blank")
     }
 }

--- a/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/GradleEnterpriseApi.kt
+++ b/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/GradleEnterpriseApi.kt
@@ -65,8 +65,12 @@ interface GradleEnterpriseApi {
 }
 
 internal class RealGradleEnterpriseApi(
-    override val config: Config = Config(),
+    customConfig: Config? = null,
 ) : GradleEnterpriseApi {
+
+    override val config by lazy {
+        customConfig ?: Config()
+    }
 
     private val okHttpClient by lazy {
         buildOkHttpClient(config = config)

--- a/library/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/FakeEnv.kt
+++ b/library/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/FakeEnv.kt
@@ -1,13 +1,2 @@
 package com.gabrielfeo.gradle.enterprise.api.internal
 
-class FakeEnv(
-    vararg vars: Pair<String, String?>,
-) : Env {
-
-    private val vars = vars.toMap(HashMap())
-
-    override fun get(name: String) = vars[name]
-
-    operator fun set(name: String, value: String?) = vars.put(name, value)
-    operator fun contains(name: String) = name in vars
-}

--- a/library/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/FakeKeychain.kt
+++ b/library/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/FakeKeychain.kt
@@ -1,12 +1,2 @@
 package com.gabrielfeo.gradle.enterprise.api.internal
 
-internal class FakeKeychain(
-    vararg entries: Pair<String, String>,
-) : Keychain {
-
-    private val entries = entries.toMap()
-
-    override fun get(entry: String) =
-        entries[entry]?.let { KeychainResult.Success(it) }
-            ?: KeychainResult.Error("entry $entry not mocked")
-}

--- a/library/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/FakeSystemProperties.kt
+++ b/library/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/FakeSystemProperties.kt
@@ -1,18 +1,2 @@
 package com.gabrielfeo.gradle.enterprise.api.internal
 
-class FakeSystemProperties(
-    vararg vars: Pair<String, String?>,
-) : SystemProperties {
-
-    companion object {
-        val macOs = FakeSystemProperties("os.name" to "Mac OS X")
-        val linux = FakeSystemProperties("os.name" to "Linux")
-    }
-
-    private val vars = vars.toMap(HashMap())
-
-    override fun get(name: String) = vars[name]
-
-    operator fun set(name: String, value: String?) = vars.put(name, value)
-    operator fun contains(name: String) = name in vars
-}

--- a/library/src/testFixtures/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/FakeEnv.kt
+++ b/library/src/testFixtures/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/FakeEnv.kt
@@ -1,0 +1,13 @@
+package com.gabrielfeo.gradle.enterprise.api.internal
+
+class FakeEnv(
+    vararg vars: Pair<String, String?>,
+) : Env {
+
+    private val vars = vars.toMap(HashMap())
+
+    override fun get(name: String) = vars[name]
+
+    operator fun set(name: String, value: String?) = vars.put(name, value)
+    operator fun contains(name: String) = name in vars
+}

--- a/library/src/testFixtures/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/FakeKeychain.kt
+++ b/library/src/testFixtures/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/FakeKeychain.kt
@@ -1,0 +1,12 @@
+package com.gabrielfeo.gradle.enterprise.api.internal
+
+internal class FakeKeychain(
+    vararg entries: Pair<String, String>,
+) : Keychain {
+
+    private val entries = entries.toMap()
+
+    override fun get(entry: String) =
+        entries[entry]?.let { KeychainResult.Success(it) }
+            ?: KeychainResult.Error("entry $entry not mocked")
+}

--- a/library/src/testFixtures/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/FakeSystemProperties.kt
+++ b/library/src/testFixtures/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/FakeSystemProperties.kt
@@ -1,0 +1,18 @@
+package com.gabrielfeo.gradle.enterprise.api.internal
+
+class FakeSystemProperties(
+    vararg vars: Pair<String, String?>,
+) : SystemProperties {
+
+    companion object {
+        val macOs = FakeSystemProperties("os.name" to "Mac OS X")
+        val linux = FakeSystemProperties("os.name" to "Linux")
+    }
+
+    private val vars = vars.toMap(HashMap())
+
+    override fun get(name: String) = vars[name]
+
+    operator fun set(name: String, value: String?) = vars.put(name, value)
+    operator fun contains(name: String) = name in vars
+}


### PR DESCRIPTION
Related to #73. The DefaultInstance would be initialized with the default Config eagerly when building a new instance with configuration via code. If there were no URL environment variable set, the DefaultInstance init would throw due to a missing URL in its config.

Fix by ensuring that the default Config is initialized lazily.