### PR TITLE
Stop `update-api-spec` from editing open PRs

### DIFF
--- a/.github/workflows/update-api-spec.yml
+++ b/.github/workflows/update-api-spec.yml
@@ -52,3 +52,4 @@ jobs:
           author: "github-actions <github-actions@github.com>"
           committer: "github-actions <github-actions@github.com>"
           add-paths: "gradle.properties"
+          delete-branch: true

--- a/.github/workflows/update-api-spec.yml
+++ b/.github/workflows/update-api-spec.yml
@@ -37,8 +37,9 @@ jobs:
         if: ${{ env.NEW_VERSION }}
         run: |
           set -u
-          echo "UPDATE_BRANCH='feature/api-spec-$NEW_VERSION'" >> $GITHUB_ENV
-          if git ls-remote --exit-code --heads origin "$UPDATE_BRANCH"; then
+          update_branch="feature/api-spec-$NEW_VERSION"
+          echo "UPDATE_BRANCH=$update_branch" >> $GITHUB_ENV
+          if git ls-remote --exit-code --heads origin "$update_branch"; then
             echo "EXISTING_PR=true" >> $GITHUB_ENV
           fi
       - name: 'Create PR'

--- a/.github/workflows/update-api-spec.yml
+++ b/.github/workflows/update-api-spec.yml
@@ -33,11 +33,19 @@ jobs:
             echo "NEW_VERSION=$(cat new.txt)" >> $GITHUB_ENV
           fi
           rm new.txt || true
+      - name: Check for existing PR
+        if: ${{ env.NEW_VERSION }}
+        run: |
+          set -u
+          echo "UPDATE_BRANCH='feature/api-spec-$NEW_VERSION'" >> $GITHUB_ENV
+          if git ls-remote --exit-code --heads origin "$UPDATE_BRANCH"; then
+            echo "EXISTING_PR=true" >> $GITHUB_ENV
+          fi
       - name: 'Create PR'
-        if: ${{ inputs.dry_run != true && env.NEW_VERSION }}
+        if: ${{ inputs.dry_run != true && env.NEW_VERSION && !env.EXISTING_PR }}
         uses: peter-evans/create-pull-request@v5
         with:
-          branch: "feature/api-spec-${{ env.NEW_VERSION }}"
+          branch: "${{ env.UPDATE_BRANCH }}"
           commit-message: "Bump GE API spec version to ${{ env.NEW_VERSION }}"
           title: "Bump GE API spec version to ${{ env.NEW_VERSION }}"
           body: "https://docs.gradle.com/enterprise/api-manual/#release_history"


### PR DESCRIPTION
The behavior of `peter-evans/create-pull-request` is to check if either the base or target branches have changed and either keep creating new PRs or update an open PR (default), force-pushing and editing its description.

Prevent the action from running on open PRs entirely, because API spec updates will often require manual changes to be pushed, and the workflow shouldn't force-push over them.