### PR TITLE
Update version in examples after Maven Central

### DIFF
--- a/.github/scripts/replace_string.py
+++ b/.github/scripts/replace_string.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path", type=Path, help="Path to root directory")
+    parser.add_argument("old_string", type=str, help="Old string to be replaced")
+    parser.add_argument("new_string", type=str, help="New string to replace old string")
+    args = parser.parse_args()
+    replace_string(args.path, args.old_string, args.new_string)
+
+
+def replace_string(path: Path, old_string: str, new_string: str) -> None:
+    for file in path.glob('**/*'):
+        if file.is_file():
+            text = file.read_text()
+            text = text.replace(old_string, new_string)
+            file.write_text(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_replace_string.py
+++ b/.github/scripts/test_replace_string.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import unittest
+from pathlib import Path
+from shutil import copytree
+from tempfile import TemporaryDirectory
+from replace_string import replace_string
+
+TEST_RESOURCES = Path(__file__).parent / 'test_resources'
+
+class TestReplaceString(unittest.TestCase):
+
+    def test_replace_string(self):
+        old = '0.17.0'
+        new = '0.17.1'
+        files = ('README.md', 'build.gradle.kts', 'notebook.ipynb')
+        with TemporaryDirectory() as temp_dir:
+            dir = Path(temp_dir) / 'resources'
+            copytree(TEST_RESOURCES, dir)
+            replace_string(dir, old, new)
+            for file in files:
+                self.assert_replaced(dir / file, old, new)
+
+    def assert_replaced(self, file, old, new):
+        content = file.read_text()
+        self.assertIn(new, content)
+        self.assertNotIn(old, content)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_resources/README.md
+++ b/.github/scripts/test_resources/README.md
@@ -1,0 +1,17 @@
+# Title
+
+[![Maven Central](https://img.shields.io/badge/Maven%20Central-0.17.0-blue)][14]
+
+```kotlin
+@file:DependsOn("com.gabrielfeo:gradle-enterprise-api-kotlin:0.17.0")
+```
+
+```kotlin
+implementation("com.gabrielfeo:gradle-enterprise-api-kotlin:0.17.0")
+```
+
+```
+%use gradle-enterprise-api-kotlin(version=0.17.0)
+```
+
+[14]: https://central.sonatype.com/artifact/com.gabrielfeo/gradle-enterprise-api-kotlin/0.17.0 

--- a/.github/scripts/test_resources/build.gradle.kts
+++ b/.github/scripts/test_resources/build.gradle.kts
@@ -1,0 +1,3 @@
+dependencies {
+    implementation("com.gabrielfeo:gradle-enterprise-api-kotlin:0.17.0")
+}

--- a/.github/scripts/test_resources/notebook.ipynb
+++ b/.github/scripts/test_resources/notebook.ipynb
@@ -1,0 +1,15 @@
+{
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "source": [
+    "%use gradle-enterprise-api-kotlin(version=0.17.0)"
+   ],
+   "outputs": []
+  }
+ ]
+}

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -30,7 +30,9 @@ jobs:
       - name: Build javadoc
         uses: ./.github/actions/build
         with:
-          args: 'dokkaHtml'
+          args: >-
+            dokkaHtml
+            '-Pversion=${{ github.ref_name }}'
           artifact-name: 'docs'
           path-to-upload: "library/build/dokka/html/**/*"
 

--- a/.github/workflows/update-examples.yml
+++ b/.github/workflows/update-examples.yml
@@ -1,0 +1,32 @@
+name: 'Update examples'
+
+on:
+  push:
+    tags: [ '*' ]
+  workflow_call:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  update-api-spec:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+      - name: 'Get versions'
+        run: |
+          old_version="$(git tag --sort=-v:refname | head -n 2 | tail -n 1)"
+          echo "OLD_VERSION=$old_version" >> $GITHUB_ENV
+          echo "NEW_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+      - name: 'Update version in all files'
+        run: ./.github/scripts/replace_string.py ./ "$OLD_VERSION" "$NEW_VERSION"
+      - name: 'Create PR'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          branch: "${{ env.UPDATE_BRANCH }}"
+          title: "Bump library version in examples to ${{ env.NEW_VERSION }}"
+          author: "github-actions <github-actions@github.com>"
+          committer: "github-actions <github-actions@github.com>"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gradle Enterprise API Kotlin
 
-[![Release](https://jitpack.io/v/gabrielfeo/gradle-enterprise-api-kotlin.svg)][14]
-[![Javadoc](https://img.shields.io/badge/javadoc-latest-orange)][7]
+[![Maven Central](https://img.shields.io/badge/Maven%20Central-0.16.2-blue)][14]
+[![Javadoc](https://img.shields.io/badge/Javadoc-0.16.2-orange)][7]
 
 A Kotlin library to access the [Gradle Enterprise API][1], easy to use from Kotlin
 scripts, projects or Jupyter notebooks:
@@ -29,12 +29,14 @@ That's it! You can now use the library without any code configuration from:
 
 ### Setup snippets
 
+ℹ️ The library is now published to Maven Central under `com.gabrielfeo`. Maven Central is 
+recommended over JitPack.
+
 <details>
   <summary>Add to a Kotlin script</summary>
 
 ```kotlin
-@file:Repository("https://jitpack.io")
-@file:DependsOn("com.github.gabrielfeo:gradle-enterprise-api-kotlin:0.16.0")
+@file:DependsOn("com.gabrielfeo:gradle-enterprise-api-kotlin:0.16.2")
 ```
 
 </details>
@@ -42,25 +44,9 @@ That's it! You can now use the library without any code configuration from:
 <details>
   <summary>Add to a Kotlin project</summary>
 
-Groovy
-
-```groovy
-repositories {
-  maven { url = 'https://jitpack.io' }
-}
-dependencies {
-  implementation 'com.github.gabrielfeo:gradle-enterprise-api-kotlin:0.16.0'
-}
-```
-
-Kotlin
-
 ```kotlin
-repositories {
-  maven(url = "https://jitpack.io")
-}
 dependencies {
-  implementation("com.github.gabrielfeo:gradle-enterprise-api-kotlin:0.16.0")
+  implementation("com.gabrielfeo:gradle-enterprise-api-kotlin:0.16.2")
 }
 ```
 
@@ -71,7 +57,7 @@ dependencies {
 
 ```
 %useLatestDescriptors
-%use gradle-enterprise-api-kotlin(version=0.16.0)
+%use gradle-enterprise-api-kotlin(version=0.16.2)
 ```
 
 </details>
@@ -186,7 +172,7 @@ import com.gabrielfeo.gradle.enterprise.api.model.extension.*
 [11]: https://gabrielfeo.github.io/gradle-enterprise-api-kotlin/library/com.gabrielfeo.gradle.enterprise.api/-gradle-enterprise-api/shutdown.html
 [12]: https://gabrielfeo.github.io/gradle-enterprise-api-kotlin/library/com.gabrielfeo.gradle.enterprise.api/-config/-cache-config/cache-enabled.html
 [13]: https://gabrielfeo.github.io/gradle-enterprise-api-kotlin/library/com.gabrielfeo.gradle.enterprise.api/-config/-cache-config/index.html
-[14]: https://jitpack.io/#gabrielfeo/gradle-enterprise-api-kotlin
+[14]: https://central.sonatype.com/artifact/com.gabrielfeo/gradle-enterprise-api-kotlin/0.16.2
 [16]: https://gabrielfeo.github.io/gradle-enterprise-api-kotlin/library/com.gabrielfeo.gradle.enterprise.api/-config/api-url.html
 [17]: https://gabrielfeo.github.io/gradle-enterprise-api-kotlin/library/com.gabrielfeo.gradle.enterprise.api/-config/api-token.html
 [18]: https://gabrielfeo.github.io/gradle-enterprise-api-kotlin/library/com.gabrielfeo.gradle.enterprise.api/-builds-api/index.html

--- a/examples/example-notebooks/MostFrequentBuilds.ipynb
+++ b/examples/example-notebooks/MostFrequentBuilds.ipynb
@@ -31,7 +31,7 @@
     "`%use` is [line magic](https://github.com/Kotlin/kotlin-jupyter#line-magics) of the Kotlin kernel that can do much more than adding the library. To illustrate, this setup:\n",
     "\n",
     "```kotlin\n",
-    "@file:DependsOn(\"com.github.gabrielfeo:gradle-enterprise-api-kotlin:0.15.1\")\n",
+    "@file:DependsOn(\"com.gabrielfeo:gradle-enterprise-api-kotlin:0.16.2\")\n",
     "\n",
     "import com.gabrielfeo.gradle.enterprise.api.*\n",
     "import com.gabrielfeo.gradle.enterprise.api.model.*\n",
@@ -52,7 +52,7 @@
    "outputs": [],
    "source": [
     "%useLatestDescriptors\n",
-    "%use gradle-enterprise-api-kotlin(version=0.16.0)\n",
+    "%use gradle-enterprise-api-kotlin(version=0.16.2)\n",
     "%use coroutines(v=1.7.1)"
    ]
   },

--- a/examples/example-project/app/build.gradle.kts
+++ b/examples/example-project/app/build.gradle.kts
@@ -7,11 +7,6 @@ application {
     mainClass.set("com.gabrielfeo.gradle.enterprise.api.example.MainKt")
 }
 
-repositories {
-    mavenCentral()
-    maven(url = "https://jitpack.io")
-}
-
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(8))
@@ -19,5 +14,5 @@ java {
 }
 
 dependencies {
-    implementation("com.github.gabrielfeo:gradle-enterprise-api-kotlin:0.16.0")
+    implementation("com.gabrielfeo:gradle-enterprise-api-kotlin:0.16.2")
 }

--- a/examples/example-script.main.kts
+++ b/examples/example-script.main.kts
@@ -15,8 +15,7 @@
  *   legacy tests. We should suggest they run test instead, leaving check for CI to run."
  */
 
-@file:Repository("https://jitpack.io")
-@file:DependsOn("com.github.gabrielfeo:gradle-enterprise-api-kotlin:0.16.0")
+@file:DependsOn("com.gabrielfeo:gradle-enterprise-api-kotlin:0.16.2")
 
 import com.gabrielfeo.gradle.enterprise.api.*
 import com.gabrielfeo.gradle.enterprise.api.model.*


### PR DESCRIPTION
Update library version and groupId in README and all examples, following the move from JitPack to Maven Central. Also write a workflow to do this automatically when new version (tag) is released.