### PR TITLE
Simplify examples

### DIFF
--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -1,0 +1,39 @@
+val exampleTestTasks = ArrayList<TaskProvider<*>>()
+
+exampleTestTasks += tasks.register<Exec>("runExampleScript") {
+    group = "Application"
+    description = "Runs the 'example-script.main.kts' script"
+    commandLine("kotlinc", "-script", file("example-script.main.kts"))
+}
+
+exampleTestTasks += tasks.register<GradleBuild>("checkExampleProject") {
+    group = "Verification"
+    description = "Checks examples/example-project as a standalone build"
+    dir = file("example-project")
+    tasks = listOf("check")
+}
+
+val notebooks = fileTree(file("example-notebooks")) {
+    exclude(".ipynb_checkpoints")
+}
+
+exampleTestTasks += notebooks.map { notebook ->
+    val buildDir = project.layout.buildDirectory.asFile.get()
+    tasks.register<Exec>("run${notebook.nameWithoutExtension}Notebook") {
+        group = "Application"
+        description = "Runs the '${notebook.name}' notebook"
+        commandLine(
+            "jupyter", "nbconvert",
+            "--execute",
+            "--to", "ipynb",
+            "--output-dir=$buildDir",
+            notebook,
+        )
+    }
+}
+
+tasks.register("checkExamples") {
+    group = "Verification"
+    description = "Checks all examples"
+    dependsOn(exampleTestTasks)
+}

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -6,11 +6,11 @@ exampleTestTasks += tasks.register<Exec>("runExampleScript") {
     commandLine("kotlinc", "-script", file("example-script.main.kts"))
 }
 
-exampleTestTasks += tasks.register<GradleBuild>("checkExampleProject") {
+exampleTestTasks += tasks.register<GradleBuild>("runExampleProject") {
     group = "Verification"
-    description = "Checks examples/example-project as a standalone build"
+    description = "Runs examples/example-project as a standalone build"
     dir = file("example-project")
-    tasks = listOf("check")
+    tasks = listOf("run")
 }
 
 val notebooks = fileTree(file("example-notebooks")) {
@@ -21,7 +21,7 @@ exampleTestTasks += notebooks.map { notebook ->
     val buildDir = project.layout.buildDirectory.asFile.get()
     tasks.register<Exec>("run${notebook.nameWithoutExtension}Notebook") {
         group = "Application"
-        description = "Runs the '${notebook.name}' notebook"
+        description = "Runs the '${notebook.name}' notebook with 'jupyter nbconvert --execute'"
         commandLine(
             "jupyter", "nbconvert",
             "--execute",
@@ -32,8 +32,8 @@ exampleTestTasks += notebooks.map { notebook ->
     }
 }
 
-tasks.register("checkExamples") {
-    group = "Verification"
-    description = "Checks all examples"
+tasks.register("runExamples") {
+    group = "Application"
+    description = "Runs everything in 'examples' directory"
     dependsOn(exampleTestTasks)
 }

--- a/examples/example-notebooks/MostFrequentBuilds.ipynb
+++ b/examples/example-notebooks/MostFrequentBuilds.ipynb
@@ -31,7 +31,7 @@
    "source": [
     "## Setup\n",
     "\n",
-    "`%use` is [line magic](https://github.com/Kotlin/kotlin-jupyter#line-magics) of the Kotlin kernel that can do much more than adding the library. To illustrate, this setup:\n",
+    "`%use` is a [line magic](https://github.com/Kotlin/kotlin-jupyter#line-magics) of the Kotlin kernel that can do much more than adding the library. To illustrate, this setup:\n",
     "\n",
     "```kotlin\n",
     "@file:DependsOn(\"com.gabrielfeo:gradle-enterprise-api-kotlin:0.16.2\")\n",
@@ -87,41 +87,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "39f57804-ca90-4d7b-b4ac-f8d438ba911e",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "// A utility to print progress as builds are fetched. You may ignore this.\n",
-    "\n",
-    "fun <T> Flow<T>.printProgress(produceMsg: (i: Int, current: T) -> String): Flow<T> {\n",
-    "    var i = -1\n",
-    "    var current: T? = null\n",
-    "    fun printIt() {\n",
-    "        val msg = current?.let { produceMsg(i, it) } ?: \"Waiting for elements...\"\n",
-    "        print(\"\\r$msg\".padEnd(100))\n",
-    "    }\n",
-    "    val periodicPrinter = GlobalScope.launch {\n",
-    "        while (true) {\n",
-    "            printIt()\n",
-    "            delay(500)\n",
-    "        }\n",
-    "    }\n",
-    "    return onEach {\n",
-    "        i++\n",
-    "        current = it\n",
-    "    }.onCompletion {\n",
-    "        periodicPrinter.cancelAndJoin()\n",
-    "        printIt()\n",
-    "        println(\"\\nEnd\")\n",
-    "    }\n",
-    "}"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "9d0556e7",
    "metadata": {},
@@ -135,21 +100,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "588a699f",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fetched 000006412 builds, currently 2023-05-19T19:29:58.350Z                                                      \n",
-      "End\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import java.time.temporal.*\n",
     "import java.util.LinkedList\n",
@@ -158,10 +114,7 @@
     "    val startMilli = startDate.atStartOfDay(ZoneId.of(\"UTC\")).toInstant().toEpochMilli()\n",
     "    GradleEnterpriseApi.buildsApi.getGradleAttributesFlow(since = startMilli)\n",
     "        .filter(buildFilter)\n",
-    "        .printProgress { i, build ->\n",
-    "            val buildDate = Instant.ofEpochMilli(build.buildStartTime).atOffset(ZoneOffset.UTC)\n",
-    "            String.format(\"Fetched %09d builds, currently %s\", i + 1, buildDate)\n",
-    "        }.toList(LinkedList())\n",
+    "        .toList(LinkedList())\n",
     "}"
    ]
   },
@@ -177,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "5cd75a65-a819-497e-87c2-f0911cc1554f",
    "metadata": {},
    "outputs": [
@@ -404,7 +357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "adbd028f-d30a-489e-94bd-d8f968a659a3",
    "metadata": {
     "tags": []
@@ -412,96 +365,7 @@
    "outputs": [
     {
      "data": {
-      "application/kotlindataframe+json": {
-       "columns": [
-        "tasks",
-        "count"
-       ],
-       "kotlin_dataframe": [
-        {
-         "count": 3173,
-         "tasks": "app:assembleBrazilDebug"
-        },
-        {
-         "count": 974,
-         "tasks": "IDE sync"
-        },
-        {
-         "count": 205,
-         "tasks": "droid-cli:installDist"
-        },
-        {
-         "count": 147,
-         "tasks": "clean"
-        },
-        {
-         "count": 92,
-         "tasks": "feature:order-delivery:customer-satisfaction:impl:compileReleaseSources"
-        },
-        {
-         "count": 85,
-         "tasks": "infrastructure:design-system:compose:compileReleaseSources"
-        },
-        {
-         "count": 54,
-         "tasks": "app:assembleBrazilDebug :app:installBrazilDebug"
-        },
-        {
-         "count": 51,
-         "tasks": "build-plugins:functionalTest --tests rasp.AndroidRaspProtectionPluginTest"
-        },
-        {
-         "count": 44,
-         "tasks": "analytics-braze:testReleaseUnitTest --tests br.com.ifood.analytics.braze.AppBrazeAnalyticsProviderTest"
-        },
-        {
-         "count": 44,
-         "tasks": "feature:survey:impl:compileReleaseSources"
-        },
-        {
-         "count": 33,
-         "tasks": "clean app:assembleBrazilDebug"
-        },
-        {
-         "count": 31,
-         "tasks": "feature:voucher-android-training:impl:compileReleaseSources"
-        },
-        {
-         "count": 30,
-         "tasks": "feature:search:impl:compileReleaseSources"
-        },
-        {
-         "count": 29,
-         "tasks": "droid-cli:run --args ci run-jupyter-notebook"
-        },
-        {
-         "count": 27,
-         "tasks": "clean :feature:internal-settings:sample:assemble"
-        },
-        {
-         "count": 24,
-         "tasks": "clean :app:assembleBrazilDebug"
-        },
-        {
-         "count": 20,
-         "tasks": "protectArtifact"
-        },
-        {
-         "count": 19,
-         "tasks": "analytics-braze:testReleaseUnitTest --tests br.com.ifood.analytics.braze.AppBrazeAnalyticsProviderTest.sendEvent_featureFlagCanSendEvent_sendEvent"
-        },
-        {
-         "count": 19,
-         "tasks": "setupDependencies"
-        },
-        {
-         "count": 16,
-         "tasks": "feature:checkout:core:impl:testReleaseUnitTest --tests br.com.ifood.checkout.presentation.plugin.standard.delivery.DeliveryPluginViewModelTest"
-        }
-       ],
-       "ncol": 2,
-       "nrow": 682
-      },
+      "application/kotlindataframe+json": "{\"nrow\":266,\"ncol\":2,\"columns\":[\"tasks\",\"count\"],\"kotlin_dataframe\":[{\"tasks\":\"app:assembleBrazilDebug\",\"count\":977},{\"tasks\":\"IDE sync\",\"count\":285},{\"tasks\":\"droid-cli:installDist\",\"count\":80},{\"tasks\":\"feature:order-delivery:waiting-platform-components:impl:compileReleaseSources\",\"count\":48},{\"tasks\":\"feature:home:impl:compileReleaseSources\",\"count\":17},{\"tasks\":\"feature:chat:impl:testReleaseUnitTest --tests br.com.ifood.chat.presentation.chat.viewModel.ChatViewModelTest.dispatchViewAction_withInitializeAction_andChatCreated_\",\"count\":16},{\"tasks\":\"clean\",\"count\":13},{\"tasks\":\"analytics-braze:testReleaseUnitTest --tests br.com.ifood.analytics.braze.AppBrazeAnalyticsProviderTest.sendEvent_featureFlagCanSendEvent_sendEvent\",\"count\":12},{\"tasks\":\"analytics-braze:testReleaseUnitTest --tests br.com.ifood.analytics.braze.AppBrazeAnalyticsProviderTest\",\"count\":12},{\"tasks\":\"app:assembleBrazilDebug :app:installBrazilDebug\",\"count\":11},{\"tasks\":\"buildPlugin\",\"count\":11},{\"tasks\":\"infrastructure:design-system:global-components-sample:assembleDebug\",\"count\":11},{\"tasks\":\"setupDependencies\",\"count\":10},{\"tasks\":\"feature:groceries:shopping-list:impl:testReleaseUnitTest --tests br.com.ifood.groceries.shoppinglist.presentation.shoppinglistvoice.ShoppingListVoiceSharedViewModelTest\",\"count\":8},{\"tasks\":\"feature:review:evaluating:impl:testReleaseUnitTest --tests br.com.ifood.review.presentation.viewmodel.ReviewViewModelTest\",\"count\":7},{\"tasks\":\"build-plugins:test --tests rasp.DexProtectorConfigManagerTest\",\"count\":7},{\"tasks\":\"build-plugins:functionalTest --tests rasp.AndroidRaspProtectionPluginTest\",\"count\":7},{\"tasks\":\"droid-cli:test --tests br.com.ifood.cli.util.RunCommandShellTest\",\"count\":7},{\"tasks\":\"feature:order-delivery:waiting:impl:testReleaseUnitTest\",\"count\":6},{\"tasks\":\"feature:checkout:core:impl:testReleaseUnitTest --tests br.com.ifood.checkout.presentation.contextcard.mapper.CartModelToMinimizedCartUiModelMapperTest\",\"count\":5}]}",
       "text/html": [
        "        <html>\n",
        "        <head>\n",
@@ -663,26 +527,26 @@
        "        </head>\n",
        "        <body>\n",
        "            \n",
-       "<table class=\"dataframe\" id=\"df_637534208\"></table>\n",
+       "<table class=\"dataframe\" id=\"df_1275068416\"></table>\n",
        "\n",
-       "<p class=\"dataframe_description\">... showing only top 20 of 682 rows</p><p class=\"dataframe_description\">DataFrame: rowsCount = 682, columnsCount = 2</p>\n",
+       "<p class=\"dataframe_description\">... showing only top 20 of 266 rows</p><p class=\"dataframe_description\">DataFrame: rowsCount = 266, columnsCount = 2</p>\n",
        "        </body>\n",
        "        <script>\n",
        "            \n",
        "/*<!--*/\n",
-       "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: \"<span title=\\\"tasks: String\\\">tasks</span>\", children: [], rightAlign: false, values: [\"app:assembleBrazilDebug\",\"IDE sync\",\"droid-cli:installDist\",\"clean\",\"<span class=\\\"formatted\\\" title=\\\"feature:order-delivery:customer-satisfaction:impl:compileReleaseSources\\\">feature:order-delivery:customer-satis<span class=\\\"structural\\\">...</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"infrastructure:design-system:compose:compileReleaseSources\\\">infrastructure:design-system:compose:<span class=\\\"structural\\\">...</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"app:assembleBrazilDebug :app:installBrazilDebug\\\">app:assembleBrazilDebug :app:installB<span class=\\\"structural\\\">...</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"build-plugins:functionalTest --tests rasp.AndroidRaspProtectionPluginTest\\\">build-plugins:functionalTest --tests <span class=\\\"structural\\\">...</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"analytics-braze:testReleaseUnitTest --tests br.com.ifood.analytics.braze.AppBrazeAnalyticsProviderTest\\\">analytics-braze:testReleaseUnitTest -<span class=\\\"structural\\\">...</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"feature:survey:impl:compileReleaseSources\\\">feature:survey:impl:compileReleaseSou<span class=\\\"structural\\\">...</span></span>\",\"clean app:assembleBrazilDebug\",\"<span class=\\\"formatted\\\" title=\\\"feature:voucher-android-training:impl:compileReleaseSources\\\">feature:voucher-android-training:impl<span class=\\\"structural\\\">...</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"feature:search:impl:compileReleaseSources\\\">feature:search:impl:compileReleaseSou<span class=\\\"structural\\\">...</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"droid-cli:run --args ci run-jupyter-notebook\\\">droid-cli:run --args ci run-jupyter-n<span class=\\\"structural\\\">...</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"clean :feature:internal-settings:sample:assemble\\\">clean :feature:internal-settings:samp<span class=\\\"structural\\\">...</span></span>\",\"clean :app:assembleBrazilDebug\",\"protectArtifact\",\"<span class=\\\"formatted\\\" title=\\\"analytics-braze:testReleaseUnitTest --tests br.com.ifood.analytics.braze.AppBrazeAnalyticsProviderTest.sendEvent_featureFlagCanSendEvent_sendEvent\\\">analytics-braze:testReleaseUnitTest -<span class=\\\"structural\\\">...</span></span>\",\"setupDependencies\",\"<span class=\\\"formatted\\\" title=\\\"feature:checkout:core:impl:testReleaseUnitTest --tests br.com.ifood.checkout.presentation.plugin.standard.delivery.DeliveryPluginViewModelTest\\\">feature:checkout:core:impl:testReleas<span class=\\\"structural\\\">...</span></span>\"] }, \n",
-       "{ name: \"<span title=\\\"count: Int\\\">count</span>\", children: [], rightAlign: true, values: [\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">3173</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">974</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">205</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">147</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">92</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">85</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">54</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">51</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">44</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">44</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">33</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">31</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">30</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">29</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">27</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">24</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">20</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">19</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">19</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">16</span></span>\"] }, \n",
-       "], id: 637534208, rootId: 637534208, totalRows: 682 } ) });\n",
+       "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: \"<span title=\\\"tasks: String\\\">tasks</span>\", children: [], rightAlign: false, values: [\"app:assembleBrazilDebug\",\"IDE sync\",\"droid-cli:installDist\",\"<span class=\\\"formatted\\\" title=\\\"feature:order-delivery:waiting-platform-components:impl:compileReleaseSources\\\">feature:order-delivery:waiting-platfo<span class=\\\"structural\\\">...</span></span>\",\"feature:home:impl:compileReleaseSources\",\"<span class=\\\"formatted\\\" title=\\\"feature:chat:impl:testReleaseUnitTest --tests br.com.ifood.chat.presentation.chat.viewModel.ChatViewModelTest.dispatchViewAction_withInitializeAction_andChatCreated_\\\">feature:chat:impl:testReleaseUnitTest<span class=\\\"structural\\\">...</span></span>\",\"clean\",\"<span class=\\\"formatted\\\" title=\\\"analytics-braze:testReleaseUnitTest --tests br.com.ifood.analytics.braze.AppBrazeAnalyticsProviderTest.sendEvent_featureFlagCanSendEvent_sendEvent\\\">analytics-braze:testReleaseUnitTest -<span class=\\\"structural\\\">...</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"analytics-braze:testReleaseUnitTest --tests br.com.ifood.analytics.braze.AppBrazeAnalyticsProviderTest\\\">analytics-braze:testReleaseUnitTest -<span class=\\\"structural\\\">...</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"app:assembleBrazilDebug :app:installBrazilDebug\\\">app:assembleBrazilDebug :app:installB<span class=\\\"structural\\\">...</span></span>\",\"buildPlugin\",\"<span class=\\\"formatted\\\" title=\\\"infrastructure:design-system:global-components-sample:assembleDebug\\\">infrastructure:design-system:global-c<span class=\\\"structural\\\">...</span></span>\",\"setupDependencies\",\"<span class=\\\"formatted\\\" title=\\\"feature:groceries:shopping-list:impl:testReleaseUnitTest --tests br.com.ifood.groceries.shoppinglist.presentation.shoppinglistvoice.ShoppingListVoiceSharedViewModelTest\\\">feature:groceries:shopping-list:impl:<span class=\\\"structural\\\">...</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"feature:review:evaluating:impl:testReleaseUnitTest --tests br.com.ifood.review.presentation.viewmodel.ReviewViewModelTest\\\">feature:review:evaluating:impl:testRe<span class=\\\"structural\\\">...</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"build-plugins:test --tests rasp.DexProtectorConfigManagerTest\\\">build-plugins:test --tests rasp.DexPr<span class=\\\"structural\\\">...</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"build-plugins:functionalTest --tests rasp.AndroidRaspProtectionPluginTest\\\">build-plugins:functionalTest --tests <span class=\\\"structural\\\">...</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"droid-cli:test --tests br.com.ifood.cli.util.RunCommandShellTest\\\">droid-cli:test --tests br.com.ifood.c<span class=\\\"structural\\\">...</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"feature:order-delivery:waiting:impl:testReleaseUnitTest\\\">feature:order-delivery:waiting:impl:t<span class=\\\"structural\\\">...</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"feature:checkout:core:impl:testReleaseUnitTest --tests br.com.ifood.checkout.presentation.contextcard.mapper.CartModelToMinimizedCartUiModelMapperTest\\\">feature:checkout:core:impl:testReleas<span class=\\\"structural\\\">...</span></span>\"] }, \n",
+       "{ name: \"<span title=\\\"count: Int\\\">count</span>\", children: [], rightAlign: true, values: [\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">977</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">285</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">80</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">48</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">17</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">16</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">13</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">12</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">12</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">11</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">11</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">11</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">10</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">8</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">7</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">7</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">7</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">7</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">6</span></span>\",\"<span class=\\\"formatted\\\" title=\\\"\\\"><span class=\\\"numbers\\\">5</span></span>\"] }, \n",
+       "], id: 1275068416, rootId: 1275068416, totalRows: 266 } ) });\n",
        "/*-->*/\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(637534208) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(1275068416) });\n",
        "\n",
        "\n",
        "        </script>\n",
        "        </html>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -714,7 +578,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "8c28e684-0f3b-43d9-a3d2-7b1ef91fa6c4",
    "metadata": {},
    "outputs": [
@@ -772,7 +636,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "293b2b4d",
    "metadata": {
     "tags": []
@@ -785,18 +649,18 @@
        "output": {
         "data": {
          "count": [
-          3173,
-          974,
-          205,
-          147,
-          92
+          977,
+          285,
+          80,
+          48,
+          17
          ],
          "tasks": [
           "app:assembleBrazilDebug",
           "IDE sync",
           "droid-cli:installDist",
-          "clean",
-          "feature:order-delivery:customer-satisfaction:impl:compileReleaseSources"
+          "feature:order-delivery:waiting-platform-components:impl:compileReleaseSources",
+          "feature:home:impl:compileReleaseSources"
          ]
         },
         "ggsize": {
@@ -827,7 +691,8 @@
           ]
          },
          {
-          "aesthetic": "y"
+          "aesthetic": "y",
+          "discrete": true
          }
         ]
        },
@@ -836,14 +701,14 @@
       },
       "text/html": [
        "            <script type=\"text/javascript\" data-lets-plot-script=\"library\" src=\"https://cdn.jsdelivr.net/gh/JetBrains/lets-plot@v3.1.0/js-package/distr/lets-plot.min.js\"></script>    \n",
-       "               <div id=\"F3ANb8\"></div>\n",
+       "               <div id=\"vTIZUl\"></div>\n",
        "   <script type=\"text/javascript\" data-lets-plot-script=\"plot\">\n",
        "       var plotSpec={\n",
        "\"mapping\":{\n",
        "},\n",
        "\"data\":{\n",
-       "\"count\":[3173.0,974.0,205.0,147.0,92.0],\n",
-       "\"tasks\":[\"app:assembleBrazilDebug\",\"IDE sync\",\"droid-cli:installDist\",\"clean\",\"feature:order-delivery:customer-satisfaction:impl:compileReleaseSources\"]\n",
+       "\"count\":[977.0,285.0,80.0,48.0,17.0],\n",
+       "\"tasks\":[\"app:assembleBrazilDebug\",\"IDE sync\",\"droid-cli:installDist\",\"feature:order-delivery:waiting-platform-components:impl:compileReleaseSources\",\"feature:home:impl:compileReleaseSources\"]\n",
        "},\n",
        "\"ggsize\":{\n",
        "\"width\":1000.0,\n",
@@ -854,7 +719,8 @@
        "\"aesthetic\":\"x\",\n",
        "\"limits\":[null,null]\n",
        "},{\n",
-       "\"aesthetic\":\"y\"\n",
+       "\"aesthetic\":\"y\",\n",
+       "\"discrete\":true\n",
        "}],\n",
        "\"layers\":[{\n",
        "\"mapping\":{\n",
@@ -870,12 +736,12 @@
        "}\n",
        "}]\n",
        "};\n",
-       "       var plotContainer = document.getElementById(\"F3ANb8\");\n",
+       "       var plotContainer = document.getElementById(\"vTIZUl\");\n",
        "       LetsPlot.buildPlotFromProcessedSpecs(plotSpec, -1, -1, plotContainer);\n",
        "   </script>    "
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/example-project/app/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/example/analysis/MostFrequentBuilds.kt
+++ b/examples/example-project/app/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/example/analysis/MostFrequentBuilds.kt
@@ -33,12 +33,7 @@ suspend fun mostFrequentBuilds(
     val startMilli = startDate.atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli()
     val builds: List<GradleAttributes> = api.getGradleAttributesFlow(since = startMilli)
         .filter(buildFilter)
-        .onEach { build ->
-            val buildDate = Instant.ofEpochMilli(build.buildStartTime).atOffset(ZoneOffset.UTC)
-            print(String.format("\rFetching builds... (current date: %s)", buildDate))
-        }.onCompletion {
-            print('\n')
-        }.toList(LinkedList())
+        .toList(LinkedList())
 
     // Process builds and count how many times each was invoked
     val buildCounts = builds.groupBy { build ->

--- a/examples/example-script.main.kts
+++ b/examples/example-script.main.kts
@@ -36,12 +36,7 @@ val builds: List<GradleAttributes> = runBlocking {
     val startMilli = startDate.atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli()
     GradleEnterpriseApi.buildsApi.getGradleAttributesFlow(since = startMilli)
         .filter(buildFilter)
-        .onEach { build ->
-            val buildDate = Instant.ofEpochMilli(build.buildStartTime).atOffset(ZoneOffset.UTC)
-            print(String.format("\rFetching builds... (current date: %s)", buildDate))
-        }.onCompletion {
-            print('\n')
-        }.toList(LinkedList())
+        .toList(LinkedList())
 }
 
 // Process builds and count how many times each was invoked

--- a/examples/example-script.main.kts
+++ b/examples/example-script.main.kts
@@ -31,38 +31,16 @@ val buildFilter: (GradleAttributes) -> Boolean = { build ->
     "LOCAL" in build.tags
 }
 
-// A utility to print progress as builds are fetched. You may ignore this.
-fun <T> Flow<T>.printProgress(produceMsg: (i: Int, current: T) -> String): Flow<T> {
-    var i = -1
-    var current: T? = null
-    fun printIt() {
-        val msg = current?.let { produceMsg(i, it) } ?: "Waiting for elements..."
-        print("\r$msg".padEnd(100))
-    }
-    val periodicPrinter = GlobalScope.launch {
-        while (true) {
-            printIt()
-            delay(500)
-        }
-    }
-    return onEach {
-        i++
-        current = it
-    }.onCompletion {
-        periodicPrinter.cancelAndJoin()
-        printIt()
-        println("\nEnd")
-    }
-}
-
 // Fetch builds from the API
 val builds: List<GradleAttributes> = runBlocking {
     val startMilli = startDate.atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli()
     GradleEnterpriseApi.buildsApi.getGradleAttributesFlow(since = startMilli)
         .filter(buildFilter)
-        .printProgress { i, build ->
+        .onEach { build ->
             val buildDate = Instant.ofEpochMilli(build.buildStartTime).atOffset(ZoneOffset.UTC)
-            String.format("Fetched %09d builds, currently %s", i + 1, buildDate)
+            print(String.format("\rFetching builds... (current date: %s)", buildDate))
+        }.onCompletion {
+            print('\n')
         }.toList(LinkedList())
 }
 
@@ -89,5 +67,5 @@ println(
     """.trimMargin()
 )
 
-// Shutdown to end OkHttp's thread pool earlier
+// Shutdown to end background threads and allow script to exit earlier (see README)
 GradleEnterpriseApi.shutdown()


### PR DESCRIPTION
Remove progress-printing from examples in order to simplify them. Also add tasks to run all examples so that #83 doesn't happen again.