### PR TITLE
Remove DefaultInstance

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: gradle check
+      - name: gradle test
         uses: ./.github/actions/build
         with:
-          args: 'check compileIntegrationTestKotlin'
+          args: 'test compileIntegrationTestKotlin'
           # artifact-name: 'Test reports (${{matrix.runner}})'
           # path-to-upload: '**/build/reports/tests/**'
 

--- a/.github/workflows/update-examples.yml
+++ b/.github/workflows/update-examples.yml
@@ -3,7 +3,7 @@ name: 'Update examples'
 on:
   push:
     tags: [ '*' ]
-  workflow_call:
+  workflow_dispatch:
 
 defaults:
   run:

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -1,3 +1,9 @@
+@file:Suppress("HasPlatformType")
+
+plugins {
+    base
+}
+
 val exampleTestTasks = ArrayList<TaskProvider<*>>()
 
 exampleTestTasks += tasks.register<Exec>("runExampleScript") {
@@ -32,8 +38,12 @@ exampleTestTasks += notebooks.map { notebook ->
     }
 }
 
-tasks.register("runAll") {
+val runAll = tasks.register("runAll") {
     group = "Application"
     description = "Runs everything in 'examples' directory"
     dependsOn(exampleTestTasks)
+}
+
+tasks.named("check") {
+    dependsOn(runAll)
 }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -208,6 +208,10 @@ kotlin {
     }
 }
 
+tasks.named("check") {
+    dependsOn("integrationTest")
+}
+
 java {
     consistentResolution {
         useRuntimeClasspathVersions()

--- a/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/GradleEnterpriseApiIntegrationTest.kt
+++ b/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/internal/GradleEnterpriseApiIntegrationTest.kt
@@ -10,12 +10,13 @@ import kotlin.test.Test
 class GradleEnterpriseApiIntegrationTest {
 
     @Test
-    fun canFetchBuildsWithDefaultInstance() = runTest {
+    fun canFetchBuildsWithDefaultConfig() = runTest {
         env = RealEnv
         keychain = RealKeychain(RealSystemProperties)
-        val builds = GradleEnterpriseApi.buildsApi.getBuilds(since = 0, maxBuilds = 1)
+        val api = GradleEnterpriseApi.newInstance()
+        val builds = api.buildsApi.getBuilds(since = 0, maxBuilds = 1)
         assertEquals(1, builds.size)
-        GradleEnterpriseApi.shutdown()
+        api.shutdown()
     }
 
     @Test

--- a/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/GradleEnterpriseApi.kt
+++ b/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/GradleEnterpriseApi.kt
@@ -55,25 +55,18 @@ interface GradleEnterpriseApi {
     companion object {
 
         /**
-         * Create a new instance of `GradleEnterpriseApi` with the default `Config`.
-         */
-        fun newInstance(): GradleEnterpriseApi = RealGradleEnterpriseApi()
-
-        /**
          * Create a new instance of `GradleEnterpriseApi` with a custom `Config`.
          */
-        fun newInstance(config: Config): GradleEnterpriseApi = RealGradleEnterpriseApi(config)
+        fun newInstance(config: Config = Config()): GradleEnterpriseApi {
+            return RealGradleEnterpriseApi(config)
+        }
     }
 
 }
 
 internal class RealGradleEnterpriseApi(
-    customConfig: Config? = null,
+    override val config: Config,
 ) : GradleEnterpriseApi {
-
-    override val config by lazy {
-        customConfig ?: Config()
-    }
 
     private val okHttpClient by lazy {
         buildOkHttpClient(config = config)

--- a/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/GradleEnterpriseApi.kt
+++ b/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/GradleEnterpriseApi.kt
@@ -52,14 +52,17 @@ interface GradleEnterpriseApi {
      * The default, companion instance of the Gradle Enterprise API client. See
      * [GradleEnterpriseApi].
      */
-    companion object DefaultInstance : GradleEnterpriseApi by RealGradleEnterpriseApi() {
+    companion object {
 
         /**
-         * Create a new instance of `GradleEnterpriseApi` with new options.
+         * Create a new instance of `GradleEnterpriseApi` with the default `Config`.
          */
-        fun newInstance(config: Config): GradleEnterpriseApi {
-            return RealGradleEnterpriseApi(config)
-        }
+        fun newInstance(): GradleEnterpriseApi = RealGradleEnterpriseApi()
+
+        /**
+         * Create a new instance of `GradleEnterpriseApi` with a custom `Config`.
+         */
+        fun newInstance(config: Config): GradleEnterpriseApi = RealGradleEnterpriseApi(config)
     }
 
 }


### PR DESCRIPTION
Removing `DefaultInstance` further cleans up the library API so that its entrypoint is more familiar and easier to grasp with autocomplete. It's not much effort to build an instance before using.

Also make the `check` task run integration tests and examples, and switch CI to run `test` instead. CI can't run integration or examples because it doesn't have an API token. Also fix the `update-examples` workflow to support `workflow_dispatch`.