### PR TITLE
Fix update-examples workflow

### DIFF
--- a/.github/scripts/replace_string.py
+++ b/.github/scripts/replace_string.py
@@ -17,13 +17,17 @@ def main() -> None:
 
 def replace_string(path: Path, old_string: str, new_string: str) -> None:
     repo = git.Repo(path, search_parent_directories=True)
+    print(f'Replacing {old_string} for {new_string}...')
     for file in path.glob('**/*'):
         if not should_replace(repo, file):
             continue
         try:
             text = file.read_text()
+            if old_string not in text:
+                continue
             text = text.replace(old_string, new_string)
             file.write_text(text)
+            print(f'Replaced in file {file}')
         except UnicodeError as e:
             print(f'Error processing file {file}:', e, file=sys.stderr)
 

--- a/.github/workflows/update-examples.yml
+++ b/.github/workflows/update-examples.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
 
-  update-api-spec:
+  update-examples:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'

--- a/.github/workflows/update-examples.yml
+++ b/.github/workflows/update-examples.yml
@@ -27,6 +27,7 @@ jobs:
       - name: 'Create PR'
         uses: peter-evans/create-pull-request@v5
         with:
+          base: 'main'
           branch: "${{ env.UPDATE_BRANCH }}"
           title: "Bump library version in examples to ${{ env.NEW_VERSION }}"
           author: "github-actions <github-actions@github.com>"

--- a/.github/workflows/update-examples.yml
+++ b/.github/workflows/update-examples.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - run: pip install -r .github/scripts/requirements.txt
       - name: 'Get versions'
         run: |

--- a/.github/workflows/update-examples.yml
+++ b/.github/workflows/update-examples.yml
@@ -28,7 +28,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           base: 'main'
-          branch: "${{ env.UPDATE_BRANCH }}"
+          branch: "replace-${{ env.OLD_VERSION }}-${{ env.NEW_VERSION }}"
           title: "Bump library version in examples to ${{ env.NEW_VERSION }}"
           author: "github-actions <github-actions@github.com>"
           committer: "github-actions <github-actions@github.com>"


### PR DESCRIPTION
- define `base` for create-pull-request, required when running on tags
- fix the branch parameter, which referenced an old, deleted variable
- increase `fetch-depth` so that job has older tags present