### PR TITLE
Replace `getGradleAttributesFlow` with new operator

### DIFF
--- a/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/BuildsApiExtensions.kt
+++ b/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/BuildsApiExtensions.kt
@@ -56,19 +56,32 @@ fun BuildsApi.getBuildsFlow(
  * the endpoint providing a timeline of builds, then maps each to [BuildsApi.getGradleAttributes].
  *
  * Instead of filtering builds downstream based on `GradleAttributes` (e.g. using [Flow.filter]),
- * prefer filtering server-side using a `query` (see [BuildsApi.getBuilds]).
+ * prefer filtering server-side before mapping (see [BuildsApi.getBuilds]).
  *
  * ### Buffering
  *
- * Will request eagerly and buffer up to [Int.MAX_VALUE] calls.
+ * Will request eagerly and buffer up to [Int.MAX_VALUE] calls. To set buffer size, use
+ * [BuildsApi.getBuildsFlow] + [mapToGradleAttributes] instead.
  *
  * ### Concurrency
  *
  * Attributes are requested concurrently in coroutines started in [scope]. The number of
  * concurrent requests underneath is still limited by [Config.maxConcurrentRequests].
  *
- * @param scope CoroutineScope in which to create coroutines. Defaults to [GlobalScope].
+ * @param scope CoroutineScope in which to create coroutines. If bufferSize < 1, no coroutines
+ * are started. Defaults to [GlobalScope].
  */
+@Deprecated(
+    "Use mapToGradleAttributes instead. This function will be removed in the next release.",
+    replaceWith = ReplaceWith(
+        "getBuildsFlow(since, sinceBuild, fromInstant, fromBuild, query, reverse, maxWaitSecs)" +
+            ".mapToGradleAttributes(api, scope)",
+        imports = [
+            "com.gabrielfeo.gradle.enterprise.api.extension.getBuildsFlow",
+            "com.gabrielfeo.gradle.enterprise.api.extension.mapToGradleAttributes",
+        ]
+    ),
+)
 @OptIn(DelicateCoroutinesApi::class)
 fun BuildsApi.getGradleAttributesFlow(
     since: Long = 0,
@@ -88,6 +101,4 @@ fun BuildsApi.getGradleAttributesFlow(
         query = query,
         reverse = reverse,
         maxWaitSecs = maxWaitSecs,
-    ).withGradleAttributes(scope, api = this).map { (_, attrs) ->
-        attrs
-    }
+    ).mapToGradleAttributes(api = this, scope = scope)

--- a/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/BuildsApiExtensions.kt
+++ b/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/BuildsApiExtensions.kt
@@ -61,7 +61,7 @@ fun BuildsApi.getBuildsFlow(
  * ### Buffering
  *
  * Will request eagerly and buffer up to [Int.MAX_VALUE] calls. To set buffer size, use
- * [BuildsApi.getBuildsFlow] + [mapToGradleAttributes] instead.
+ * [BuildsApi.getBuildsFlow] + [mapToGradleAttributesConcurrent] instead.
  *
  * ### Concurrency
  *
@@ -72,13 +72,13 @@ fun BuildsApi.getBuildsFlow(
  * are started. Defaults to [GlobalScope].
  */
 @Deprecated(
-    "Use mapToGradleAttributes instead. This function will be removed in the next release.",
+    "Use mapToGradleAttributesConcurrent instead. This function will be removed in the next release.",
     replaceWith = ReplaceWith(
         "getBuildsFlow(since, sinceBuild, fromInstant, fromBuild, query, reverse, maxWaitSecs)" +
-            ".mapToGradleAttributes(api, scope)",
+            ".mapToGradleAttributesConcurrent(api, scope)",
         imports = [
             "com.gabrielfeo.gradle.enterprise.api.extension.getBuildsFlow",
-            "com.gabrielfeo.gradle.enterprise.api.extension.mapToGradleAttributes",
+            "com.gabrielfeo.gradle.enterprise.api.extension.mapToGradleAttributesConcurrent",
         ]
     ),
 )
@@ -101,4 +101,4 @@ fun BuildsApi.getGradleAttributesFlow(
         query = query,
         reverse = reverse,
         maxWaitSecs = maxWaitSecs,
-    ).mapToGradleAttributes(api = this, scope = scope)
+    ).mapToGradleAttributesConcurrent(api = this, scope = scope)

--- a/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/Mapping.kt
+++ b/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/Mapping.kt
@@ -6,20 +6,42 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 
 /**
- * Joins builds with their [GradleAttributes], which comes from a different endpoint
+ * Maps [Build]s ([BuildsApi.getBuilds]) to their [GradleAttributes]
  * ([BuildsApi.getGradleAttributes]).
  *
- * Don't expect client-side filtering to be efficient. Does as many concurrent calls
- * as it can, requesting attributes in an eager coroutine, in [scope].
+ * Instead of filtering builds downstream based on `GradleAttributes` (e.g. using [Flow.filter]),
+ * prefer filtering server-side before mapping (see [BuildsApi.getBuilds]).
+ *
+ * ### Buffering
+ *
+ * If [bufferSize] > 0, will request attributes lazily as builds are collected, else will request
+ * eagerly and buffer up to [bufferSize] calls.
+ *
+ * ### Concurrency
+ *
+ * Attributes are requested concurrently in coroutines started in [scope]. The number of
+ * concurrent requests underneath is still limited by [Config.maxConcurrentRequests].
+ *
+ * @param scope CoroutineScope in which to create coroutines. If bufferSize < 1, no coroutines
+ * are started. Defaults to [GlobalScope].
+ * @param bufferSize Buffer capacity (see [Flow.buffer])
  */
-internal fun Flow<Build>.withGradleAttributes(
-    scope: CoroutineScope,
+@OptIn(DelicateCoroutinesApi::class)
+fun Flow<Build>.mapToGradleAttributes(
     api: BuildsApi,
-): Flow<Pair<Build, GradleAttributes>> =
-    map { build ->
-        build to scope.async {
+    scope: CoroutineScope = GlobalScope,
+    bufferSize: Int = Int.MAX_VALUE,
+): Flow<GradleAttributes> {
+    if (bufferSize < 1) {
+        return map { build ->
             api.getGradleAttributes(build.id)
         }
-    }.buffer(Int.MAX_VALUE).map { (build, attrs) ->
-        build to attrs.await()
     }
+    return map { build ->
+        scope.async {
+            api.getGradleAttributes(build.id)
+        }
+    }.buffer(bufferSize).map {
+        it.await()
+    }
+}

--- a/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/Mapping.kt
+++ b/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/Mapping.kt
@@ -7,10 +7,14 @@ import kotlinx.coroutines.flow.*
 
 /**
  * Maps [Build]s ([BuildsApi.getBuilds]) to their [GradleAttributes]
- * ([BuildsApi.getGradleAttributes]).
+ * ([BuildsApi.getGradleAttributes]) concurrently.
  *
- * Instead of filtering builds downstream based on `GradleAttributes` (e.g. using [Flow.filter]),
- * prefer filtering server-side before mapping (see [BuildsApi.getBuilds]).
+ * This is a faster alternative to mapping sequentially, i.e.
+ * `map { api.getGradleAttributes(it.id) }`.
+ *
+ * Note: instead of filtering builds downstream based on `GradleAttributes` (e.g. using
+ * [Flow.filter]), prefer filtering server-side before mapping with a `query` (see
+ * [BuildsApi.getBuilds]).
  *
  * ### Buffering
  *
@@ -27,7 +31,7 @@ import kotlinx.coroutines.flow.*
  * @param bufferSize Buffer capacity (see [Flow.buffer])
  */
 @OptIn(DelicateCoroutinesApi::class)
-fun Flow<Build>.mapToGradleAttributes(
+fun Flow<Build>.mapToGradleAttributesConcurrent(
     api: BuildsApi,
     scope: CoroutineScope = GlobalScope,
     bufferSize: Int = Int.MAX_VALUE,

--- a/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/Mapping.kt
+++ b/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/Mapping.kt
@@ -18,8 +18,9 @@ import kotlinx.coroutines.flow.*
  *
  * ### Buffering
  *
- * If [bufferSize] > 0, will request attributes lazily as builds are collected, else will request
- * eagerly and buffer up to [bufferSize] calls.
+ * If [bufferSize] > 0, will map builds eagerly and concurrently, buffering according to
+ * `bufferSize` (see [Flow.buffer]). If `bufferSize` <= 0, will map sequentially, same as
+ * `map { api.getGradleAttributes(it.id) }`.
  *
  * ### Concurrency
  *

--- a/library/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/MappingTest.kt
+++ b/library/src/test/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/MappingTest.kt
@@ -1,7 +1,7 @@
 package com.gabrielfeo.gradle.enterprise.api.internal.operator
 
 import com.gabrielfeo.gradle.enterprise.api.FakeBuildsApi
-import com.gabrielfeo.gradle.enterprise.api.extension.mapToGradleAttributes
+import com.gabrielfeo.gradle.enterprise.api.extension.mapToGradleAttributesConcurrent
 import com.gabrielfeo.gradle.enterprise.api.model.FakeBuild
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
@@ -27,8 +27,8 @@ class MappingTest {
         get() = api.getGradleAttributesCallCount.value
 
     @Test
-    fun `mapToGradleAttributes maps builds in order`() = runTest {
-        val attrs = api.builds.asFlow().mapToGradleAttributes(api, scope = this).toList()
+    fun `mapToGradleAttributesConcurrent maps builds in order`() = runTest {
+        val attrs = api.builds.asFlow().mapToGradleAttributesConcurrent(api, scope = this).toList()
         assertEquals(5, callCount)
         assertEquals(5, attrs.size)
         attrs.indices.forEach { i ->
@@ -37,15 +37,15 @@ class MappingTest {
     }
 
     @Test
-    fun `mapToGradleAttributes(bufferSize=1), then GradleAttributes fetched eagerly`() =
+    fun `mapToGradleAttributesConcurrent(bufferSize=1), then GradleAttributes fetched eagerly`() =
         testWithNeverEndingCollector(bufferSize = 1, expectedRequests = 3)
 
     @Test
-    fun `mapToGradleAttributes(bufferSize=0), then GradleAttributes fetched lazily`() =
+    fun `mapToGradleAttributesConcurrent(bufferSize=0), then GradleAttributes fetched lazily`() =
         testWithNeverEndingCollector(bufferSize = 0, expectedRequests = 1)
 
     @Test
-    fun `mapToGradleAttributes(bufferSize=-1), then GradleAttributes fetched lazily`() =
+    fun `mapToGradleAttributesConcurrent(bufferSize=-1), then GradleAttributes fetched lazily`() =
         testWithNeverEndingCollector(bufferSize = -1, expectedRequests = 1)
 
     private fun testWithNeverEndingCollector(
@@ -53,7 +53,7 @@ class MappingTest {
         expectedRequests: Int,
     ) = runTest {
         backgroundScope.launch {
-            api.builds.asFlow().mapToGradleAttributes(api, scope = this, bufferSize)
+            api.builds.asFlow().mapToGradleAttributesConcurrent(api, scope = this, bufferSize)
                 .collect {
                     // Make the first collect never complete, simulating a slow collector
                     Job().join()


### PR DESCRIPTION
Replace `getGradleAttributesFlow` with new operator to not hide the official API, but extend it.