### PR TITLE
Bump library version in examples to 2023.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gradle Enterprise API Kotlin
 
-[![Maven Central](https://img.shields.io/badge/Maven%20Central-2023.3.0-blue)][14]
-[![Javadoc](https://img.shields.io/badge/Javadoc-2023.3.0-orange)][7]
+[![Maven Central](https://img.shields.io/badge/Maven%20Central-2023.3.1-blue)][14]
+[![Javadoc](https://img.shields.io/badge/Javadoc-2023.3.1-orange)][7]
 
 A Kotlin library to access the [Gradle Enterprise API][1], easy to use from:
 
@@ -52,7 +52,7 @@ recommended over JitPack.
 
 ```
 %useLatestDescriptors
-%use gradle-enterprise-api-kotlin(version=2023.3.0)
+%use gradle-enterprise-api-kotlin(version=2023.3.1)
 ```
 
 </details>
@@ -61,7 +61,7 @@ recommended over JitPack.
   <summary>Add to a Kotlin script</summary>
 
 ```kotlin
-@file:DependsOn("com.gabrielfeo:gradle-enterprise-api-kotlin:2023.3.0")
+@file:DependsOn("com.gabrielfeo:gradle-enterprise-api-kotlin:2023.3.1")
 ```
 
 </details>
@@ -71,7 +71,7 @@ recommended over JitPack.
 
 ```kotlin
 dependencies {
-  implementation("com.gabrielfeo:gradle-enterprise-api-kotlin:2023.3.0")
+  implementation("com.gabrielfeo:gradle-enterprise-api-kotlin:2023.3.1")
 }
 ```
 
@@ -190,7 +190,7 @@ import com.gabrielfeo.gradle.enterprise.api.model.extension.*
 [11]: https://gabrielfeo.github.io/gradle-enterprise-api-kotlin/library/com.gabrielfeo.gradle.enterprise.api/-gradle-enterprise-api/shutdown.html
 [12]: https://gabrielfeo.github.io/gradle-enterprise-api-kotlin/library/com.gabrielfeo.gradle.enterprise.api/-config/-cache-config/cache-enabled.html
 [13]: https://gabrielfeo.github.io/gradle-enterprise-api-kotlin/library/com.gabrielfeo.gradle.enterprise.api/-config/-cache-config/index.html
-[14]: https://central.sonatype.com/artifact/com.gabrielfeo/gradle-enterprise-api-kotlin/2023.3.0
+[14]: https://central.sonatype.com/artifact/com.gabrielfeo/gradle-enterprise-api-kotlin/2023.3.1
 [16]: https://gabrielfeo.github.io/gradle-enterprise-api-kotlin/library/com.gabrielfeo.gradle.enterprise.api/-config/api-url.html
 [17]: https://gabrielfeo.github.io/gradle-enterprise-api-kotlin/library/com.gabrielfeo.gradle.enterprise.api/-config/api-token.html
 [18]: https://gabrielfeo.github.io/gradle-enterprise-api-kotlin/library/com.gabrielfeo.gradle.enterprise.api/-builds-api/index.html

--- a/examples/example-notebooks/MostFrequentBuilds.ipynb
+++ b/examples/example-notebooks/MostFrequentBuilds.ipynb
@@ -35,7 +35,7 @@
     "Add libraries to use, via line magics. `%use` is a [line magic](https://github.com/Kotlin/kotlin-jupyter#line-magics) of the Kotlin kernel that can do much more than adding the library. To illustrate, this setup can be replaced with a single line magic.\n",
     "\n",
     "```kotlin\n",
-    "@file:DependsOn(\"com.gabrielfeo:gradle-enterprise-api-kotlin:2023.3.0\")\n",
+    "@file:DependsOn(\"com.gabrielfeo:gradle-enterprise-api-kotlin:2023.3.1\")\n",
     "\n",
     "import com.gabrielfeo.gradle.enterprise.api.*\n",
     "import com.gabrielfeo.gradle.enterprise.api.model.*\n",
@@ -45,7 +45,7 @@
     "is the same as:\n",
     "\n",
     "```\n",
-    "%use gradle-enterprise-api-kotlin(version=2023.3.0)\n",
+    "%use gradle-enterprise-api-kotlin(version=2023.3.1)\n",
     "```"
    ]
   },
@@ -57,7 +57,7 @@
    "outputs": [],
    "source": [
     "%useLatestDescriptors\n",
-    "%use gradle-enterprise-api-kotlin(version=2023.3.0)\n",
+    "%use gradle-enterprise-api-kotlin(version=2023.3.1)\n",
     "%use coroutines(v=1.7.1)"
    ]
   },

--- a/examples/example-project/app/build.gradle.kts
+++ b/examples/example-project/app/build.gradle.kts
@@ -14,5 +14,5 @@ java {
 }
 
 dependencies {
-    implementation("com.gabrielfeo:gradle-enterprise-api-kotlin:2023.3.0")
+    implementation("com.gabrielfeo:gradle-enterprise-api-kotlin:2023.3.1")
 }

--- a/examples/example-script.main.kts
+++ b/examples/example-script.main.kts
@@ -17,7 +17,7 @@
  * Run this with at least 1GB of heap to accomodate the fetched data: JAVA_OPTS=-Xmx1g
  */
 
-@file:DependsOn("com.gabrielfeo:gradle-enterprise-api-kotlin:2023.3.0")
+@file:DependsOn("com.gabrielfeo:gradle-enterprise-api-kotlin:2023.3.1")
 
 import com.gabrielfeo.gradle.enterprise.api.*
 import com.gabrielfeo.gradle.enterprise.api.model.*


### PR DESCRIPTION
The GH action couldn't bump it due to that tag and main having diverged (was a patch release with cherry-pick).