### PR TITLE
Support 2023.4 models param

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -124,6 +124,21 @@ tasks.openApiGenerate.configure {
             }
         }
     }
+    // Fix mapping of BuildModelName: gradle-attributes -> gradleAttributes
+    doLast {
+        ant.withGroovyBuilder {
+            "replaceregexp"(
+                "match" to "Minus",
+                "replace" to "",
+                "flags" to "mg",
+            ) {
+                "fileset"(
+                    "dir" to srcDir,
+                    "includes" to "com/gabrielfeo/gradle/enterprise/api/model/BuildModelName.kt",
+                )
+            }
+        }
+    }
 }
 
 sourceSets {

--- a/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/BuildsApiExtensions.kt
+++ b/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/BuildsApiExtensions.kt
@@ -32,6 +32,7 @@ fun BuildsApi.getBuildsFlow(
     reverse: Boolean? = null,
     maxWaitSecs: Int? = null,
     buildsPerPage: Int = API_MAX_BUILDS,
+    models: List<BuildModelName>? = null,
 ): Flow<Build> {
     return flow {
         var builds = getBuilds(
@@ -43,6 +44,7 @@ fun BuildsApi.getBuildsFlow(
             reverse = reverse,
             maxWaitSecs = maxWaitSecs,
             maxBuilds = buildsPerPage,
+            models = models,
         )
         emitAll(builds.asFlow())
         while (builds.isNotEmpty()) {
@@ -86,6 +88,7 @@ fun BuildsApi.getGradleAttributesFlow(
     reverse: Boolean? = null,
     maxWaitSecs: Int? = null,
     scope: CoroutineScope = GlobalScope,
+    models: List<BuildModelName>? = null,
 ): Flow<GradleAttributes> =
     getBuildsFlow(
         since = since,
@@ -95,6 +98,7 @@ fun BuildsApi.getGradleAttributesFlow(
         query = query,
         reverse = reverse,
         maxWaitSecs = maxWaitSecs,
+        models = models,
     ).withGradleAttributes(scope, api = this).map { (_, attrs) ->
         attrs
     }

--- a/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/BuildsApiExtensions.kt
+++ b/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/BuildsApiExtensions.kt
@@ -78,6 +78,18 @@ fun BuildsApi.getBuildsFlow(
  *
  * @param scope CoroutineScope in which to create coroutines. Defaults to [GlobalScope].
  */
+@Deprecated(
+    "Use `getBuildsFlow(models = listOf(BuildModelName.gradleAttributes))` instead. " +
+        "This function will be removed in the next release.",
+    replaceWith = ReplaceWith(
+        "getBuildsFlow(since, sinceBuild, fromInstant, fromBuild, query, reverse," +
+            "maxWaitSecs, models = listOf(BuildModelName.gradleAttributes))",
+        imports = [
+            "com.gabrielfeo.gradle.enterprise.api.extension.getBuildsFlow",
+            "com.gabrielfeo.gradle.enterprise.api.model.BuildModelName",
+        ]
+    ),
+)
 @OptIn(DelicateCoroutinesApi::class)
 fun BuildsApi.getGradleAttributesFlow(
     since: Long = 0,


### PR DESCRIPTION
2023.4 supports passing a models parameter to `/api/builds` to get GradleAttributes and others in a single request. `getGradleAttributesFlow` is deprecated in favor of the new parameter.