### PR TITLE
Fix builds paging when models param is used

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -227,6 +227,10 @@ tasks.named("check") {
     dependsOn("integrationTest")
 }
 
+tasks.named<Test>("integrationTest") {
+    jvmArgs("-Xmx512m")
+}
+
 java {
     consistentResolution {
         useRuntimeClasspathVersions()

--- a/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/BuildsApiExtensionsIntegrationTest.kt
+++ b/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/BuildsApiExtensionsIntegrationTest.kt
@@ -2,25 +2,64 @@ package com.gabrielfeo.gradle.enterprise.api.extension
 
 import com.gabrielfeo.gradle.enterprise.api.*
 import com.gabrielfeo.gradle.enterprise.api.internal.*
+import com.gabrielfeo.gradle.enterprise.api.model.BuildModelName
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.test.runTest
+import okhttp3.Request
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.time.Duration.Companion.minutes
+
+private val timeout = 2.minutes
 
 class BuildsApiExtensionsIntegrationTest {
 
-    @Test
-    fun getBuildsFlowUsesQueryInAllRequests() = runTest {
+    init {
         env = RealEnv
         keychain = RealKeychain(RealSystemProperties)
-        val recorder = RequestRecorder()
-        val api = buildApi(recorder)
-        api.buildsApi.getBuildsFlow(since = 0, query = "user:*").take(2000).collect()
-        recorder.requests.forEachIndexed { i, request ->
-            assertEquals("user:*", request.url.queryParameter("query"), "[$i]")
-        }
+    }
+
+    private val recorder = RequestRecorder()
+    private val api = buildApi(recorder)
+
+    @AfterTest
+    fun setup() {
         api.shutdown()
+    }
+
+    @Test
+    fun getBuildsFlowPreservesParamsAcrossRequests() = runTest(timeout = timeout) {
+        api.buildsApi.getBuildsFlow(
+            since = 0,
+            query = "user:*",
+            models = listOf(BuildModelName.gradleAttributes)
+        ).take(2000).collect()
+        recorder.requests.forEach {
+            assertUrlParam(it, "query", "user:*")
+            assertUrlParam(it, "models", "gradle-attributes")
+        }
+    }
+
+    @Test
+    fun getBuildsFlowReplacesSinceForFromBuildAfterFirstRequest() = runTest(timeout = timeout) {
+        api.buildsApi.getBuildsFlow(
+            since = 0,
+            query = "user:*",
+            models = listOf(BuildModelName.gradleAttributes)
+        ).take(2000).collect()
+        with(recorder.requests) {
+            first().let {
+                assertUrlParam(it, "since", "0")
+                assertUrlParam(it, "fromBuild", null)
+            }
+            (this - first()).forEach {
+                assertUrlParam(it, "since", null)
+                assertUrlParamNotNull(it, "fromBuild")
+            }
+        }
     }
 
     private fun buildApi(recorder: RequestRecorder) =
@@ -30,4 +69,13 @@ class BuildsApiExtensionsIntegrationTest {
                 cacheConfig = Config.CacheConfig(cacheEnabled = false),
             )
         )
+
+    private fun assertUrlParam(request: Request, key: String, expected: String?) {
+        val actual = request.url.queryParameter(key)
+        assertEquals(expected, actual, "Expected '$key='$expected', but was '$key=$actual' (${request.url})")
+    }
+
+    private fun assertUrlParamNotNull(request: Request, key: String) {
+        assertNotNull(request.url.queryParameter(key), "Expected param $key, but was null (${request.url})")
+    }
 }

--- a/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/BuildsApiExtensionsIntegrationTest.kt
+++ b/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/BuildsApiExtensionsIntegrationTest.kt
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.Assertions.*
 import kotlin.test.AfterTest
 import kotlin.time.Duration.Companion.minutes
 
-private val timeout = 2.minutes
-
 class BuildsApiExtensionsIntegrationTest {
 
     init {
@@ -30,7 +28,7 @@ class BuildsApiExtensionsIntegrationTest {
     }
 
     @Test
-    fun getBuildsFlowPreservesParamsAcrossRequests() = runTest(timeout = timeout) {
+    fun getBuildsFlowPreservesParamsAcrossRequests() = runTest(timeout = 3.minutes) {
         api.buildsApi.getBuildsFlow(
             since = 0,
             query = "user:*",
@@ -45,13 +43,13 @@ class BuildsApiExtensionsIntegrationTest {
     }
 
     @Test
-    fun getBuildsFlowReplacesSinceForFromBuildAfterFirstRequest() = runTest(timeout = timeout) {
+    fun getBuildsFlowReplacesSinceForFromBuildAfterFirstRequest() = runTest {
         api.buildsApi.getBuildsFlow(since = 1).take(2000).collect()
         assertReplacedForFromBuildAfterFirstRequest(param = "since" to "1")
     }
 
     @Test
-    fun getBuildsFlowReplacesFromInstantForFromBuildAfterFirstRequest() = runTest(timeout = timeout) {
+    fun getBuildsFlowReplacesFromInstantForFromBuildAfterFirstRequest() = runTest {
         api.buildsApi.getBuildsFlow(fromInstant = 1).take(2000).collect()
         assertReplacedForFromBuildAfterFirstRequest(param = "fromInstant" to "1")
     }

--- a/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/BuildsApiExtensionsIntegrationTest.kt
+++ b/library/src/integrationTest/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/BuildsApiExtensionsIntegrationTest.kt
@@ -34,11 +34,13 @@ class BuildsApiExtensionsIntegrationTest {
         api.buildsApi.getBuildsFlow(
             since = 0,
             query = "user:*",
-            models = listOf(BuildModelName.gradleAttributes)
+            models = listOf(BuildModelName.gradleAttributes),
+            reverse = true,
         ).take(2000).collect()
         recorder.requests.forEach {
             assertUrlParam(it, "query", "user:*")
             assertUrlParam(it, "models", "gradle-attributes")
+            assertUrlParam(it, "reverse", "true")
         }
     }
 

--- a/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/BuildsApiExtensions.kt
+++ b/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/extension/BuildsApiExtensions.kt
@@ -54,6 +54,7 @@ fun BuildsApi.getBuildsFlow(
                 reverse = reverse,
                 maxWaitSecs = maxWaitSecs,
                 maxBuilds = buildsPerPage,
+                models = models,
             )
             emitAll(builds.asFlow())
         }


### PR DESCRIPTION
Preserve the `models` param across `/api/builds` requests of `getBuildsFlow`. Add more integration tests.

When the `models` param is used with `getBuildsFlow`, requests after the first one (paging) don't send the `models` param, but they should. This is the same issue faced with `query` (#134), due to this extension being manually implemented. More integration test coverage should help.