### PR TITLE
Migrate to gradle/actions/dependency-submission

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,25 +33,6 @@ jobs:
   readme-links-test:
     uses: ./.github/workflows/test-readme-links.yml
 
-  dependency-submission:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Generate and submit dependency graph
-        uses: gradle/actions/dependency-submission@v3
-
-  dependency-review:
-    needs: dependency-submission
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Perform dependency review
-        uses: actions/dependency-review-action@v3
-        with:
-          comment-summary-in-pr: on-failure
-
   generated-api-diff:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,6 +33,25 @@ jobs:
   readme-links-test:
     uses: ./.github/workflows/test-readme-links.yml
 
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v3
+
+  dependency-review:
+    needs: dependency-submission
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Perform dependency review
+        uses: actions/dependency-review-action@v3
+        with:
+          comment-summary-in-pr: on-failure
+
   generated-api-diff:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -22,7 +22,5 @@ jobs:
         uses: actions/checkout@v4
       - name: Submit Gradle dependencies
         uses: gradle/actions/dependency-submission@v3
-        with:
-          dependency-graph: 'generate-and-submit'
         env:
           DEPENDENCY_GRAPH_EXCLUDE_CONFIGURATIONS: '.*[Tt]est(Compile|Runtime)Classpath'

--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -20,10 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Gradle
-        uses: ./.github/actions/build
       - name: Submit Gradle dependencies
-        uses: gradle/actions/gradle-dependency-submission@v3
+        uses: gradle/actions/dependency-submission@v3
         with:
           dependency-graph: 'generate-and-submit'
         env:

--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -23,10 +23,8 @@ jobs:
       - name: Set up Gradle
         uses: ./.github/actions/build
       - name: Submit Gradle dependencies
-        uses: mikepenz/gradle-dependency-submission@v0.9.2
+        uses: gradle/actions/gradle-dependency-submission@v3
         with:
-          use-gradlew: false
-          include-build-environment: true
-          gradle-build-configuration-mapping: |
-            :library|compileClasspath
-            :library|runtimeClasspath
+          dependency-graph: 'generate-and-submit'
+        env:
+          DEPENDENCY_GRAPH_EXCLUDE_CONFIGURATIONS: '.*[Tt]est(Compile|Runtime)Classpath'


### PR DESCRIPTION
`mikepenz/gradle-dependency-submission` is superseded by `gradle/actions/dependency-submission`.

Tested with [workflow_run](https://github.com/gabrielfeo/gradle-enterprise-api-kotlin/actions/runs/8474440982/job/23220812657)