### PR TITLE
Add missing APIs to GradleEnterpriseApi

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -201,6 +201,7 @@ testing {
         register<JvmTestSuite>("integrationTest") {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+                implementation("com.google.guava:guava:33.1.0-jre")
             }
         }
         withType<JvmTestSuite>().configureEach {

--- a/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/GradleEnterpriseApi.kt
+++ b/library/src/main/kotlin/com/gabrielfeo/gradle/enterprise/api/GradleEnterpriseApi.kt
@@ -35,6 +35,8 @@ interface GradleEnterpriseApi {
 
     val buildsApi: BuildsApi
     val buildCacheApi: BuildCacheApi
+    val projectsApi: ProjectsApi
+    val testsApi: TestsApi
     val metaApi: MetaApi
     val testDistributionApi: TestDistributionApi
 
@@ -78,6 +80,8 @@ internal class RealGradleEnterpriseApi(
 
     override val buildsApi: BuildsApi by lazy { retrofit.create() }
     override val buildCacheApi: BuildCacheApi by lazy { retrofit.create() }
+    override val projectsApi: ProjectsApi by lazy { retrofit.create() }
+    override val testsApi: TestsApi by lazy { retrofit.create() }
     override val metaApi: MetaApi by lazy { retrofit.create() }
     override val testDistributionApi: TestDistributionApi by lazy { retrofit.create() }
 


### PR DESCRIPTION
The beta `ProjectsApi` (added in 2023.3) and `TestsApi` (added in 2023.4) weren't accessible from `GradleEnterpriseApi`. Fix and an integration test to prevent it from happening again.