### PR TITLE
Declare library version in gradle.properties

### DIFF
--- a/.github/scripts/test_update_api_spec_version.py
+++ b/.github/scripts/test_update_api_spec_version.py
@@ -34,12 +34,12 @@ class TestCheckForNewApiSpec(unittest.TestCase):
 
     def assert_properties_version(self, file, version):
         with open(file.name) as file:
-            expected = f"gradle.enterprise.version={version}\n1=2\n"
+            expected = f"gradle.enterprise.version={version}\nversion={version}.0\n1=2\n"
             self.assertEqual(file.read(), expected)
 
     def properties_file(self, version):
         file = NamedTemporaryFile()
-        content = f"gradle.enterprise.version={version}\n1=2\n"
+        content = f"gradle.enterprise.version={version}\nversion={version}.0\n1=2\n"
         file.write(content.encode())
         file.flush()
         return file

--- a/.github/scripts/update_api_spec_version.py
+++ b/.github/scripts/update_api_spec_version.py
@@ -41,8 +41,12 @@ def update_version(properties_file, new_version):
     for line in fileinput.input(properties_file, inplace=True):
         if '=' in line:
             k, v = line.strip().split('=', maxsplit=2)
+            # Update target API spec version
             if k == 'gradle.enterprise.version':
                 line = f"{k}={new_version}\n"
+            # Update library version
+            if k == 'version':
+                line = f"{k}={new_version}.0\n"
         sys.stdout.write(line)
 
 

--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -27,6 +27,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Verify that version property matches tag
+        if: ${{ inputs.dry_run != true }}
+        run: grep -qP '^version=${{ github.ref_name }}$' gradle.properties
       - name: gradle publishLibraryPublicationToMavenCentralRepository
         uses: ./.github/actions/build
         with:
@@ -34,7 +37,6 @@ jobs:
           args: >-
             publishLibraryPublicationToMavenCentralRepository
             --rerun-tasks
-            '-Pversion=${{ github.ref_name }}'
             '-Pmaven.central.username=${{ secrets.MAVEN_CENTRAL_USERNAME }}'
             '-Pmaven.central.password=${{ secrets.MAVEN_CENTRAL_PASSWORD }}'
             '-Psigning.password=${{ secrets.GPG_PASSWORD }}'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,8 @@
+group=com.gabrielfeo
+artifact=gradle-enterprise-api-kotlin
+version=2023.4.0
+gradle.enterprise.version=2023.4
 org.gradle.jvmargs=-Xmx5g
 org.gradle.caching=true
 # Becomes default in Gradle 9.0
 org.gradle.kotlin.dsl.skipMetadataVersionCheck=false
-version=SNAPSHOT
-# Must be later than 2022.1
-gradle.enterprise.version=2023.4
-group=com.gabrielfeo
-artifact=gradle-enterprise-api-kotlin


### PR DESCRIPTION
The release flow could be more standard. Currently:

1. version on source code is always `SNAPSHOT`
2. Tag is pushed, e.g. `2023.4.0` (`version=SNAPSHOT` even on tag ref)
3. A `publish` build is ran on tag ref to publish the artifact passing `-Pversion=2023.4.0`
4. The README is only then updated on main for the new version (on tag ref, the README is obsolete)

But in most OSS projects, the version on source code corresponds to the version that code was released in, e.g. `version=2023.3.0` on the `2023.3.0` tag ref, and `main` declares the next version, `version=2023.4.0` ("Prepare for next release" commits). Adjusting to this also makes README versioning more intuitive.