### PR TITLE
Extract test suite setup to plugin

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,9 @@
+@file:Suppress("UnstableApiUsage")
+
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23")
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,8 @@
+@file:Suppress("UnstableApiUsage")
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}

--- a/build-logic/src/main/kotlin/com/gabrielfeo/kotlin-jvm-library.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/kotlin-jvm-library.gradle.kts
@@ -1,0 +1,5 @@
+package com.gabrielfeo
+
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+}

--- a/build-logic/src/main/kotlin/com/gabrielfeo/test-suites.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/test-suites.gradle.kts
@@ -1,0 +1,40 @@
+package com.gabrielfeo
+
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+    `java-test-fixtures`
+}
+
+testing {
+    suites {
+        // 'test' is registered by default
+        register<JvmTestSuite>("integrationTest")
+        withType<JvmTestSuite>().configureEach {
+            useKotlinTest()
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn("integrationTest")
+}
+
+kotlin {
+    target {
+        val main by compilations.getting
+        val integrationTest by compilations.getting
+        val test by compilations.getting
+        val testFixtures by compilations.getting
+        test.associateWith(main)
+        test.associateWith(testFixtures)
+        integrationTest.associateWith(main)
+        integrationTest.associateWith(testFixtures)
+        testFixtures.associateWith(main)
+    }
+}
+
+// TODO Unapply test-fixtures and delete the source set, since we're not publishing it?
+components.getByName<AdhocComponentWithVariants>("java").apply {
+    withVariantsFromConfiguration(configurations["testFixturesApiElements"]) { skip() }
+    withVariantsFromConfiguration(configurations["testFixturesRuntimeElements"]) { skip() }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "1.9.23" apply false
     id("org.jetbrains.dokka") version "1.9.20" apply false
     id("org.openapi.generator") version "7.3.0" apply false
 }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -5,13 +5,13 @@ import org.jetbrains.dokka.DokkaConfiguration.Visibility.PUBLIC
 import org.jetbrains.dokka.gradle.DokkaTask
 
 plugins {
-    id("org.jetbrains.kotlin.jvm")
+    id("com.gabrielfeo.kotlin-jvm-library")
+    id("com.gabrielfeo.test-suites")
     id("org.jetbrains.dokka")
     id("org.openapi.generator")
     `java-library`
-    `java-test-fixtures`
     `maven-publish`
-    `signing`
+    signing
 }
 
 val repoUrl = "https://github.com/gabrielfeo/gradle-enterprise-api-kotlin"
@@ -158,11 +158,6 @@ java {
     }
 }
 
-components.getByName<AdhocComponentWithVariants>("java").apply {
-    withVariantsFromConfiguration(configurations["testFixturesApiElements"]) { skip() }
-    withVariantsFromConfiguration(configurations["testFixturesRuntimeElements"]) { skip() }
-}
-
 tasks.withType<DokkaTask>().configureEach {
     dokkaSourceSets.all {
         sourceLink {
@@ -187,45 +182,6 @@ tasks.withType<DokkaTask>().configureEach {
 
 tasks.named<Jar>("javadocJar") {
     from(tasks.dokkaHtml)
-}
-
-testing {
-    suites {
-        getByName<JvmTestSuite>("test") {
-            dependencies {
-                implementation("com.squareup.okhttp3:mockwebserver:4.12.0")
-                implementation("com.squareup.okio:okio:3.9.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0")
-            }
-        }
-        register<JvmTestSuite>("integrationTest") {
-            dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0")
-                implementation("com.google.guava:guava:33.1.0-jre")
-            }
-        }
-        withType<JvmTestSuite>().configureEach {
-            useKotlinTest()
-        }
-    }
-}
-
-kotlin {
-    target {
-        val main by compilations.getting
-        val integrationTest by compilations.getting
-        val test by compilations.getting
-        val testFixtures by compilations.getting
-        test.associateWith(main)
-        test.associateWith(testFixtures)
-        integrationTest.associateWith(main)
-        integrationTest.associateWith(testFixtures)
-        testFixtures.associateWith(main)
-    }
-}
-
-tasks.named("check") {
-    dependsOn("integrationTest")
 }
 
 tasks.named<Test>("integrationTest") {
@@ -253,6 +209,11 @@ dependencies {
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
     implementation("org.slf4j:slf4j-api:2.0.11")
     implementation("ch.qos.logback:logback-classic:1.4.14")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testImplementation("com.squareup.okio:okio:3.9.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0")
+    integrationTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0")
+    integrationTestImplementation("com.google.guava:guava:33.1.0-jre")
 }
 
 publishing {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,7 @@
+pluginManagement {
+    includeBuild("./build-logic")
+}
+
 plugins {
     id("com.gradle.enterprise") version("3.13.2")
     id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")


### PR DESCRIPTION
`:library` build logic became convoluted. Splitting it into discrete convention plugins improves maintainability.

Create a `build-logic` project and extract test suite setup to it as a precompiled script plugin.