### PR TITLE
Bump openapi-generator from 7.3.0 to 7.4.0

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -18,6 +18,6 @@ gradlePlugin {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23")
-    implementation("org.openapitools:openapi-generator-gradle-plugin:7.3.0")
+    implementation("org.openapitools:openapi-generator-gradle-plugin:7.4.0")
     "functionalTestImplementation"(project)
 }

--- a/build-logic/src/main/kotlin/com/gabrielfeo/develocity-api-code-generation.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/develocity-api-code-generation.gradle.kts
@@ -51,6 +51,7 @@ openApiGenerate {
     invokerPackage.set("com.gabrielfeo.develocity.api.internal")
     additionalProperties.put("library", "jvm-retrofit2")
     additionalProperties.put("useCoroutines", true)
+    additionalProperties.put("enumPropertyNaming", "camelCase")
     cleanupOutput.set(true)
 }
 


### PR DESCRIPTION
Bump but keep current API by setting `enumPropertyNaming`. New default in 7.4.0 is to always match the spec, but it uses snake_case and hurts Kotlin conventions.