### PR TITLE
Fix version replacement for alpha to stable bump

### DIFF
--- a/.github/workflows/update-examples.yml
+++ b/.github/workflows/update-examples.yml
@@ -30,8 +30,8 @@ jobs:
             "Git v:refname doesn't handle Maven version qualifiers correctly."
           git tag -d "$new"
           old="$(git tag --sort=-v:refname | head -n 1)"
-          echo "NEW_VERSION=$new" | tee -a $GITHUB_ENV
           echo "OLD_VERSION=$old" | tee -a $GITHUB_ENV
+          echo "NEW_VERSION=$new" | tee -a $GITHUB_ENV
       - name: 'Update version in all files'
         run: ./.github/scripts/replace_string.py ./ "$OLD_VERSION" "$NEW_VERSION"
       - name: 'Create PR'


### PR DESCRIPTION
Version replacement would fail when replacing an alpha version for its next stable version, because Git `v:refname` tag sorting puts qualified versions (e.g. `1.0-alpha01`) after non-qualified ones (`1.0`).

Tested manually with [dispatch](https://github.com/gabrielfeo/develocity-api-kotlin/actions/runs/10814010943/job/29999397756), which resulted in #314.