### PR TITLE
Migrate away from Sonatype OSSRH

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -32,5 +32,6 @@ dependencies {
     implementation(libs.kotlin.binary.compatibility.validator.plugin)
     implementation(libs.dokka.plugin)
     implementation(libs.openapi.generator.plugin)
+    implementation(libs.vanniktech.mavenPublishPlugin)
     "functionalTestImplementation"(project)
 }

--- a/build-logic/src/main/kotlin/com/gabrielfeo/published-kotlin-jvm-library.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/published-kotlin-jvm-library.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     `java-library`
     `maven-publish`
     signing
+    id("com.vanniktech.maven.publish.base")
     id("org.jetbrains.kotlinx.binary-compatibility-validator")
     id("org.jetbrains.dokka")
 }
@@ -47,23 +48,8 @@ tasks.named<Jar>("javadocJar") {
     from(tasks.dokkaHtml)
 }
 
-publishing {
-    repositories {
-        maven {
-            name = "mavenCentral"
-            val releasesRepoUrl = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-            val snapshotsRepoUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-            val isSnapshot = version.toString().endsWith("SNAPSHOT")
-            url = if (isSnapshot) snapshotsRepoUrl else releasesRepoUrl
-            authentication {
-                register<BasicAuthentication>("basic")
-            }
-            credentials {
-                username = project.properties["maven.central.username"] as String?
-                password = project.properties["maven.central.password"] as String?
-            }
-        }
-    }
+mavenPublishing {
+    publishToMavenCentral()
 }
 
 fun isCI() = System.getenv("CI").toBoolean()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ kotlin-binary-compatibility-validator = "0.18.1"
 slf4j = "2.0.17"
 logback = "1.5.18"
 guava = "33.4.8-jre"
+maven-publish-plugin = "0.34.0"
 
 [libraries]
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
@@ -39,3 +40,4 @@ slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 logback-core = { module = "ch.qos.logback:logback-core", version.ref = "logback" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
+vanniktech-mavenPublishPlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "maven-publish-plugin" }


### PR DESCRIPTION
Migrate to the Publisher API through a community plugin, vanniktech/gradle-maven-publish-plugin.

#### References

- https://central.sonatype.org/pages/ossrh-eol/
- https://cookbook.gradle.org/integrations/maven-central/publishing/#choosing-a-plugin-for-maven-central-publishing