### PR TITLE
Fix publish-library workflow properties

### DIFF
--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -42,8 +42,8 @@ jobs:
             publishDevelocityApiKotlinPublicationToMavenCentralRepository
             publishRelocationPublicationToMavenCentralRepository
             --rerun-tasks
-            '-Pmaven.central.username=${{ secrets.MAVEN_CENTRAL_USERNAME }}'
-            '-Pmaven.central.password=${{ secrets.MAVEN_CENTRAL_PASSWORD }}'
+            '-PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }}'
+            '-PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }}'
             '-Psigning.password=${{ secrets.GPG_PASSWORD }}'
             '-Psigning.secretKey=${{ secrets.GPG_SECRET_KEY }}'
           artifact-name: 'outputs'


### PR DESCRIPTION
Update properties in the workflow that should've been edited in #479.

Caused https://github.com/gabrielfeo/develocity-api-kotlin/actions/runs/17631030709