### PR TITLE
Fix README link check retrying on HTTP 429

### DIFF
--- a/.github/link-check-config.json
+++ b/.github/link-check-config.json
@@ -1,4 +1,5 @@
 {
+  "retryOn429": true,
   "retryCount": 3,
   "fallbackRetryDelay": "120s",
   "replacementPatterns": [


### PR DESCRIPTION
retryCount and fallbackRetryDelay are both gated on retryOn429,
which defaults to false, so neither had any effect. GitHub throttles
one arbitrary URL of the concurrent batch, failing the job on a link
that is alive and passes in the next run.
