### PR TITLE
Update org.openapitools:openapi-generator-gradle-plugin to v7.24.0

### DIFF
--- a/build-logic/src/main/kotlin/com/gabrielfeo/develocity-api-code-generation.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/develocity-api-code-generation.gradle.kts
@@ -27,12 +27,9 @@ val downloadApiSpec by tasks.registering {
 
 openApiGenerate {
     generatorName = "kotlin"
-    inputSpec = downloadApiSpec.map { it.outputs.files.first().absolutePath }
-    val generateDir = project.layout.buildDirectory.dir("generated-api")
-        .map { it.asFile.absolutePath }
-    outputDir = generateDir
-    val ignoreFile = project.layout.projectDirectory.file(".openapi-generator-ignore")
-    ignoreFileOverride.set(ignoreFile.asFile.absolutePath)
+    inputSpec = downloadApiSpec.map { it.outputs.files.singleFile }
+    outputDir = project.layout.buildDirectory.dir("generated-api")
+    ignoreFileOverride = project.layout.projectDirectory.file(".openapi-generator-ignore")
     apiPackage = "com.gabrielfeo.develocity.api"
     modelPackage = "com.gabrielfeo.develocity.api.model"
     packageName = "com.gabrielfeo.develocity.api.internal"
@@ -45,10 +42,7 @@ openApiGenerate {
 }
 
 val postProcessGeneratedApi by tasks.registering(PostProcessGeneratedApi::class) {
-    val generatedSrc = tasks.openApiGenerate
-        .flatMap { it.outputDir }
-        .map { File(it) }
-    originalFiles.convention(project.layout.dir(generatedSrc))
+    originalFiles.convention(tasks.openApiGenerate.flatMap { it.outputDir })
     postProcessedFiles.convention(project.layout.buildDirectory.dir("post-processed-api"))
     modelsPackage.convention(tasks.openApiGenerate.flatMap { it.modelPackage })
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "2.3.20"
 kotlin-stdlib = "2.3.20"
 dokka = "2.2.0"
-openapi-generator = "7.21.0"
+openapi-generator = "7.24.0"
 jupyter = "0.15.0-650"
 okio = "3.18.1"
 moshi = "1.15.2"


### PR DESCRIPTION
openapi-generator-gradle-plugin 7.22.0 changed inputSpec, outputDir and
ignoreFileOverride from Property<String> to RegularFileProperty and
DirectoryProperty. Its compatibility shims only accept String, not the
Provider<String> this build passes, so :build-logic:compileKotlin failed.
Assign the file and directory providers directly instead.